### PR TITLE
fix(deps): align rand family with smartcore on rand 0.10 (supersedes #125)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.26.7"
+version = "0.26.8"
 dependencies = [
  "approx 0.5.1",
  "arrow",
@@ -379,7 +379,7 @@ dependencies = [
  "once_cell",
  "ordered-float 5.3.0",
  "parquet",
- "rand 0.9.5",
+ "rand",
  "rand_chacha",
  "rand_distr",
  "rand_pcg",
@@ -498,7 +498,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -894,7 +894,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1498,42 +1498,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1544,30 +1525,30 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.5",
+ "rand",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1804,7 +1785,7 @@ dependencies = [
  "num",
  "num-traits",
  "ordered-float 5.3.0",
- "rand 0.10.2",
+ "rand",
  "serde",
  "typetag",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.26.7"
+version = "0.26.8"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [dependencies]
-rand = "0.9.2"
+rand = "0.10.2"
 smartcore = {version = "^0.6"}
 ordered-float = "5.1.0"
 rayon = "1.11.0"
@@ -34,8 +34,8 @@ approx = "0.5.1"
 log = "0.4.28"
 env_logger = "0.11.8"
 dashmap = "6.2.1"
-rand_chacha = "0.9.0"
-rand_distr = "0.5.1"
+rand_chacha = "0.10.0"
+rand_distr = "0.6.0"
 
 # storage feature
 parquet = { version = "57.3.0", optional = true}
@@ -49,9 +49,9 @@ csv = { version = "1.4.0", optional = true }
 [dev-dependencies]
 criterion = "0.8.1"
 smartcore = {version = "^0.6", features = ["datasets"]}
-rand_pcg = "0.9.0"
+rand_pcg = "0.10.2"
 tempfile = "3.24.0"
-rand_xoshiro = "0.7.0"
+rand_xoshiro = "0.8.1"
 serial_test = "4.0"
 once_cell = "1.19"
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -820,7 +820,7 @@ impl ArrowSpaceBuilder {
 
         // generate random seed if not provided
         if self.clustering_seed.is_none() {
-            use rand::Rng;
+            use rand::RngExt;
             let mut rng = rand::rng();
             let seed: u64 = rng.random();
             self = self.with_seed(seed);
@@ -1077,7 +1077,7 @@ impl ArrowSpaceBuilder {
 
         // generate random seed if not provided
         if self.clustering_seed.is_none() {
-            use rand::Rng;
+            use rand::RngExt;
             let mut rng = rand::rng();
             let seed: u64 = rng.random();
             self = self.with_seed(seed);

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -54,7 +54,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::{info, trace};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, rngs::SysRng, RngExt, SeedableRng};
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -120,7 +120,7 @@ impl InlineSampler for SimpleRandomSampler {
         );
         Self {
             keep_rate: target_rate,
-            rng: StdRng::from_os_rng(),
+            rng: StdRng::try_from_rng(&mut SysRng).expect("OS entropy source unavailable"),
             sampled_count: AtomicUsize::new(0),
             discarded_count: AtomicUsize::new(0),
         }
@@ -181,7 +181,7 @@ impl InlineSampler for DensityAdaptiveSampler {
         Self {
             base_rate: target_rate,
             current_idx: 0,
-            rng: StdRng::from_os_rng(),
+            rng: StdRng::try_from_rng(&mut SysRng).expect("OS entropy source unavailable"),
             sampled_count: AtomicUsize::new(0),
             discarded_count: AtomicUsize::new(0),
         }

--- a/src/tests/test_clustering.rs
+++ b/src/tests/test_clustering.rs
@@ -208,7 +208,7 @@ fn test_step1_bounds_high_dimensional() {
 
 #[test]
 fn test_calinski_harabasz_well_separated() {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     let mut rows = Vec::new();
 
@@ -242,7 +242,7 @@ fn test_calinski_harabasz_well_separated() {
 
 #[test]
 fn test_calinski_harabasz_three_clusters() {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     let mut rows = Vec::new();
 
@@ -407,7 +407,7 @@ fn test_threshold_very_tight_clusters() {
 
 #[test]
 fn test_optimal_k_heuristic_synthetic_three_clusters() {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     let mut rows = Vec::new();
 
@@ -453,7 +453,7 @@ fn test_optimal_k_heuristic_synthetic_three_clusters() {
 
 #[test]
 fn test_optimal_k_heuristic_spherical_clusters() {
-    use rand::Rng;
+    use rand::RngExt;
     let mut rng = rand::rng();
     let mut rows = Vec::new();
 

--- a/src/tests/test_data.rs
+++ b/src/tests/test_data.rs
@@ -11,7 +11,7 @@ pub fn make_moons_hd(
     dims: usize,
     seed: u64,
 ) -> Vec<Vec<f64>> {
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
     use rand_pcg::Pcg64;
     use std::f64::consts::PI;
 
@@ -195,7 +195,7 @@ pub fn make_gaussian_hd(n_points: usize, noise: f64) -> Vec<Vec<f64>> {
 ///
 /// Creates 5 Gaussian clusters in 100D space with controlled separation
 pub fn make_energy_test_dataset(n_items: usize, n_features: usize, seed: u64) -> Vec<Vec<f64>> {
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
     use rand_xoshiro::Xoshiro256PlusPlus;
 
     let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
@@ -386,7 +386,7 @@ pub fn make_gaussian_cliques_multi(
     rows
 }
 
-use rand::Rng;
+use rand::RngExt;
 // Helper to generate synthetic data with controlled properties
 pub fn generate_test_data(n: usize, f: usize, seed: u64) -> Vec<Vec<f64>> {
     use rand::SeedableRng;


### PR DESCRIPTION
Completes what dependabot #125 started. smartcore `^0.6` already pulls **rand 0.10**, so bumping only `rand` left two rand majors coexisting in the tree, and the partial bump broke the build (`rand_distr 0.5`, `rand_chacha 0.9` still target rand 0.9 APIs).

### Changes
- `rand 0.9.2 -> 0.10.2`, `rand_chacha 0.9.0 -> 0.10.0`, `rand_distr 0.5.1 -> 0.6.0`
- dev-deps: `rand_pcg 0.9.0 -> 0.10.2`, `rand_xoshiro 0.7.0 -> 0.8.1`
- rand 0.10 moved `random()`/`random_range()` onto the new `RngExt` trait — imports updated in `builder.rs`, `sampling.rs`, test files
- `SeedableRng::from_os_rng()` no longer exists: replaced with `StdRng::try_from_rng(&mut SysRng)` (`OsRng` was superseded by `SysRng`)
- Cargo.lock dedupes the dual rand majors
- patch bump `0.26.7 -> 0.26.8`

Closes #125

### Verification
- `cargo build --all-features` clean
- `cargo test --all-features --release`: **293 passed, 0 failed**