### PR TITLE
perf(builder): reuse aspace.data in clustering heuristics, remove rows cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.26.9"
+version = "0.26.10"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.26.9"
+version = "0.26.10"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -136,7 +136,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
 
         // Prepare base ArrowSpace with the builder's taumode (will be used in compute_taumode)
         debug!("Creating ArrowSpace with taumode: {:?}", self.synthesis);
-        let mut aspace = ArrowSpace::new(rows.clone(), self.synthesis);
+        let mut aspace = ArrowSpace::new(rows, self.synthesis);
 
         // Configure inline sampler matching builder policy
         let sampler: Arc<Mutex<dyn InlineSampler>> = if aspace.nitems > 1000 {
@@ -185,7 +185,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
             }
 
             let (h_k, h_r, h_id) = self.compute_optimal_k(
-                &rows,
+                &aspace.data,
                 n_items,
                 n_features,
                 None,
@@ -210,7 +210,12 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
             k_opt, radius
         );
         let (clustered_dm, assignments, sizes) = run_incremental_clustering_with_sampling(
-            self, &rows, n_features, k_opt, radius, sampler,
+            self,
+            &aspace.data,
+            n_features,
+            k_opt,
+            radius,
+            sampler,
         );
 
         let n_clusters = clustered_dm.shape().0;
@@ -284,9 +289,8 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
         );
 
         // STAGE 1: Early Dimensionality Reduction (if enabled and beneficial)
-        let (working_rows, reduced_dim, projection) = if self.use_dims_reduction
-            && n_features > 1000
-        {
+        // Projection reads the rows before they are moved into the ArrowSpace.
+        let early_projection = if self.use_dims_reduction && n_features > 1000 {
             info!("Applying early JL projection to accelerate clustering");
 
             // Compute target dimension based on item count (not cluster count)
@@ -302,7 +306,8 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
             let proj = ImplicitProjection::new(n_features, target_dim, self.clustering_seed);
 
             // Project all rows in parallel using Rayon
-            let projected: Vec<Vec<f64>> = rows.par_iter().map(|row| proj.project(row)).collect();
+            let projected_flat: Vec<f64> =
+                rows.par_iter().flat_map(|row| proj.project(row)).collect();
 
             let compression = n_features as f64 / target_dim as f64;
             info!(
@@ -312,21 +317,25 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
                 (n_items * target_dim * 8) / (1024 * 1024)
             );
 
-            (projected, target_dim, Some(proj))
+            Some((proj, target_dim, projected_flat))
         } else {
             debug!("Skipping early projection (disabled or dimension too small)");
-            (rows.clone(), n_features, None)
+            None
         };
 
-        // STAGE 2: Prepare ArrowSpace (now using potentially-reduced data)
+        // STAGE 2: Prepare ArrowSpace owning the original full-dimensional data
         debug!("Creating ArrowSpace with taumode: {:?}", self.synthesis);
-        let mut aspace = ArrowSpace::new(rows.clone(), self.synthesis);
+        let mut aspace = ArrowSpace::new(rows, self.synthesis);
 
-        // Store projection metadata early
-        if let Some(proj) = projection.clone() {
+        // Heuristics and clustering operate on the projected matrix when present,
+        // otherwise directly on the data already stored in the ArrowSpace.
+        let projected_dm: Option<DenseMatrix<f64>> = early_projection.map(|(proj, rd, flat)| {
             aspace.projection_matrix = Some(proj);
-            aspace.reduced_dim = Some(reduced_dim);
-        }
+            aspace.reduced_dim = Some(rd);
+            DenseMatrix::new(n_items, rd, flat, false).unwrap()
+        });
+        let reduced_dim = projected_dm.as_ref().map_or(n_features, |dm| dm.shape().1);
+        let working_rows = projected_dm.as_ref().unwrap_or(&aspace.data);
 
         // STAGE 3: Configure Sampler
         let sampler: Arc<Mutex<dyn InlineSampler>> = if aspace.nitems > 1000 {
@@ -354,7 +363,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
             }
 
             let (k_opt, radius, intrinsic_dim) = self.compute_optimal_k(
-                &working_rows,
+                working_rows,
                 n_items,
                 n_features,
                 Some(reduced_dim),
@@ -394,7 +403,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
         );
         let (clustered_dm, assignments, sizes) = run_incremental_clustering_with_sampling(
             self,
-            &working_rows,
+            working_rows,
             reduced_dim, // Use reduced dimension for distance computations
             k_opt,
             radius,
@@ -439,7 +448,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
 
         // Prepare base ArrowSpace with the builder's taumode (will be used in compute_taumode)
         debug!("Creating ArrowSpace with taumode: {:?}", self.synthesis);
-        let mut aspace = ArrowSpace::new_from_dense(rows.clone(), self.synthesis);
+        let mut aspace = ArrowSpace::new_from_dense(rows, self.synthesis);
 
         // Configure inline sampler matching builder policy
         let sampler: Arc<Mutex<dyn InlineSampler>> = if aspace.nitems > 1000 {
@@ -464,11 +473,6 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
 
         // Auto-compute optimal clustering parameters via heuristic
         info!("Computing clustering parameters (heuristic or manual override)");
-        let compute: Vec<Vec<f64>> = (0..n_items)
-            .map(|i| rows.get_row(i).iterator(0).copied().collect())
-            .collect();
-
-        // Determine if we should run heuristics or use manual overrides
         let use_manual_k = self.cluster_max_clusters.is_some();
 
         // Run heuristic ONLY if we need any computed values
@@ -490,7 +494,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
                 panic!("`self.clustering_seed` shoud be set for full heuristics")
             }
             let (h_k, h_r, h_id) = self.compute_optimal_k(
-                &compute,
+                &aspace.data,
                 n_items,
                 n_features,
                 None,
@@ -523,7 +527,12 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
             k_opt, radius
         );
         let (clustered_dm, assignments, sizes) = run_incremental_clustering_with_sampling(
-            self, &compute, n_features, k_opt, radius, sampler,
+            self,
+            &aspace.data,
+            n_features,
+            k_opt,
+            radius,
+            sampler,
         );
 
         let n_clusters = clustered_dm.shape().0;
@@ -840,35 +849,6 @@ impl ArrowSpaceBuilder {
             self.synthesis
         );
 
-        // Save raw input if persistence is enabled
-        #[cfg(feature = "storage")]
-        {
-            if let Some((ref name, ref path)) = self.persistence {
-                use crate::storage::StorageError;
-                use crate::storage::parquet::save_dense_matrix_with_builder;
-
-                // Create temporary ArrowSpace for saving raw data
-                let temp_aspace = ArrowSpace::new(rows.clone(), self.synthesis);
-
-                use std::fs;
-                fs::create_dir_all(path).unwrap();
-
-                let saved: Result<(), StorageError> = save_dense_matrix_with_builder(
-                    &temp_aspace.data,
-                    path.clone(),
-                    &format!("{}-raw_input", name),
-                    Some(&self),
-                );
-                match saved {
-                    Ok(_) => debug!("raw-input saved"),
-                    Err(StorageError::Parquet(err)) => {
-                        panic!("saving failed for raw-input {}", err)
-                    }
-                    _ => panic!("Error with {:?}", saved),
-                };
-            }
-        }
-
         // ============================================================
         // Stage 1: Clustering with sampling and optional projection
         // ============================================================
@@ -883,11 +863,38 @@ impl ArrowSpaceBuilder {
                 "High-dimensional data detected (F={}), using fast reduce-then-cluster path",
                 n_features
             );
-            Self::start_clustering_dim_reduce(&mut self, rows.clone())
+            Self::start_clustering_dim_reduce(&mut self, rows)
         } else {
             debug!("Standard clustering path (F={} ≤ 2048)", n_features);
-            Self::start_clustering(&mut self, rows.clone())
+            Self::start_clustering(&mut self, rows)
         };
+
+        // Save raw input if persistence is enabled: the ArrowSpace holds the
+        // original dataset in `data`
+        #[cfg(feature = "storage")]
+        {
+            if let Some((ref name, ref path)) = self.persistence {
+                use crate::storage::StorageError;
+                use crate::storage::parquet::save_dense_matrix_with_builder;
+
+                use std::fs;
+                fs::create_dir_all(path).unwrap();
+
+                let saved: Result<(), StorageError> = save_dense_matrix_with_builder(
+                    &aspace.data,
+                    path.clone(),
+                    &format!("{}-raw_input", name),
+                    Some(&self),
+                );
+                match saved {
+                    Ok(_) => debug!("raw-input saved"),
+                    Err(StorageError::Parquet(err)) => {
+                        panic!("saving failed for raw-input {}", err)
+                    }
+                    _ => panic!("Error with {:?}", saved),
+                };
+            }
+        }
 
         // Save clustered centroids if persistence is enabled
         #[cfg(feature = "storage")]
@@ -1113,7 +1120,7 @@ impl ArrowSpaceBuilder {
                     n_items: _n_items,
                     n_features: _n_features,
                     ..
-                } = Self::start_clustering_dense(&mut self, rows.clone());
+                } = Self::start_clustering_dense(&mut self, rows);
 
                 // ============================================================
                 // Stage 2: Build item-graph Laplacian

--- a/src/clustering/mod.rs
+++ b/src/clustering/mod.rs
@@ -20,7 +20,7 @@ use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use rayon::prelude::*;
 use smartcore::cluster::kmeans::{KMeans, KMeansParameters};
-use smartcore::linalg::basic::arrays::Array2;
+use smartcore::linalg::basic::arrays::{Array, Array2};
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
 use crate::builder::ArrowSpaceBuilder;
@@ -68,7 +68,7 @@ pub trait ClusteringHeuristic {
     /// and estimated intrinsic dimension from NxF data matrix.
     fn compute_optimal_k(
         &self,
-        rows: &[Vec<f64>],
+        rows: &DenseMatrix<f64>,
         n: usize,
         f: usize,                   // original number of dimensions (`n_features`)
         effective_f: Option<usize>, // projected number of dimensions (if projection already happened)
@@ -93,7 +93,7 @@ pub trait ClusteringHeuristic {
 
         let sampled_rows: Vec<Vec<f64>> = sample_indices
             .par_iter()
-            .map(|&i| rows[i].clone())
+            .map(|&i| rows.get_row(i).iterator(0).copied().collect())
             .collect();
 
         let k_optimal = self.step2_calinski_harabasz(&sampled_rows, k_min, k_max, base_seed);
@@ -106,7 +106,7 @@ pub trait ClusteringHeuristic {
     // Step 1: Bounds via N/F and intrinsic dimension
     fn step1_bounds(
         &self,
-        rows: &[Vec<f64>],
+        rows: &DenseMatrix<f64>,
         n: usize,
         f: usize,                     // original number of dimensions (`n_features`)
         effective_dim: Option<usize>, // projected number of dimensions (if projection already happened)
@@ -144,7 +144,7 @@ pub trait ClusteringHeuristic {
     /// Estimate intrinsic dimension via Two-NN ratio method (DETERMINISTIC).
     fn estimate_intrinsic_dimension(
         &self,
-        rows: &[Vec<f64>],
+        rows: &DenseMatrix<f64>,
         n: usize,
         f: usize,
         base_seed: u64,
@@ -162,14 +162,14 @@ pub trait ClusteringHeuristic {
         let ratios: Vec<f64> = sample_indices
             .par_iter()
             .filter_map(|&i| {
-                let row_i = &rows[i];
+                let row_i = rows.get_row(i);
                 let mut dists: Vec<(usize, f64)> = (0..n)
                     .filter(|&j| j != i)
                     .map(|j| {
                         let d2: f64 = row_i
-                            .iter()
-                            .zip(&rows[j])
-                            .map(|(a, b)| (a - b).powi(2))
+                            .iterator(0)
+                            .zip(rows.get_row(j).iterator(0))
+                            .map(|(a, b)| (*a - *b).powi(2))
                             .sum();
                         (j, d2.sqrt())
                     })
@@ -586,13 +586,13 @@ pub fn euclidean_dist(a: &[f64], b: &[f64]) -> f64 {
 /// Returns (centroids_matrix, assignments, sizes).
 pub(crate) fn run_incremental_clustering_with_sampling(
     arrowspacebuilder: &ArrowSpaceBuilder,
-    rows: &[Vec<f64>],
+    rows: &DenseMatrix<f64>,
     nfeatures: usize,
     max_clusters: usize,
     radius: f64,
     sampler: Arc<Mutex<dyn InlineSampler>>,
 ) -> (DenseMatrix<f64>, Vec<Option<usize>>, Vec<usize>) {
-    let nrows = rows.len();
+    let nrows = rows.shape().0;
 
     info!("Starting incremental clustering with inline sampling");
     debug!(
@@ -606,7 +606,8 @@ pub(crate) fn run_incremental_clustering_with_sampling(
     let assignments = Mutex::new(vec![None; nrows]);
 
     let process_row = |row_idx: usize| {
-        let row = &rows[row_idx];
+        let row: Vec<f64> = rows.get_row(row_idx).iterator(0).copied().collect();
+        let row = row.as_slice();
 
         // ============================================================
         // PHASE 1: Snapshot and decision
@@ -687,7 +688,7 @@ pub(crate) fn run_incremental_clustering_with_sampling(
                 row_idx
             );
 
-            c.push(row.clone());
+            c.push(row.to_vec());
             k.push(1);
             a[row_idx] = Some(0);
 
@@ -734,7 +735,7 @@ pub(crate) fn run_incremental_clustering_with_sampling(
                 );
             }
 
-            c.push(row.clone());
+            c.push(row.to_vec());
             k.push(1);
             a[row_idx] = Some(new_idx);
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -467,6 +467,9 @@ impl Default for ArrowSpace {
 
 impl ArrowSpace {
     /// Returns an empty space from the initial data
+    ///
+    /// Consumes `items`, flattening them once into a row-major `DenseMatrix`
+    /// stored in `data` (NxF).
     pub(crate) fn new(items: Vec<Vec<f64>>, taumode: TauMode) -> Self {
         assert!(!items.is_empty(), "items cannot be empty");
         assert!(
@@ -475,10 +478,20 @@ impl ArrowSpace {
         );
         let n_items = items.len(); // Number of items (columns in final layout)
         let n_features = items[0].len(); // Number of features (rows in final layout)
+        let mut flat = Vec::with_capacity(n_items * n_features);
+        for row in &items {
+            assert_eq!(
+                row.len(),
+                n_features,
+                "all items must have the same number of features"
+            );
+            flat.extend_from_slice(row);
+        }
+        let data = DenseMatrix::new(n_items, n_features, flat, false).unwrap();
         Self {
             nfeatures: n_features,
             nitems: n_items,
-            data: DenseMatrix::from_2d_vec(&items).unwrap(),
+            data,
             signals: sprs::CsMat::zero((0, 0)), // will be computed later
             lambdas: vec![0.0; n_items],        // will be computed later
             lambdas_sorted: SortedLambdas::new(),
@@ -1007,10 +1020,7 @@ impl ArrowSpace {
     /// rather than discovering it as a panic (or typed error) at query time.
     #[inline]
     pub fn degenerate_lambda_count(&self) -> usize {
-        self.lambdas
-            .iter()
-            .filter(|&&l| l.abs() < 1e-12)
-            .count()
+        self.lambdas.iter().filter(|&&l| l.abs() < 1e-12).count()
     }
 
     /// Returns cluster assignment for row i (None if outlier or not clustered).
@@ -1258,9 +1268,7 @@ impl ArrowSpace {
         );
 
         if query.lambda == 0.0 {
-            return Err(ArrowSpaceError::DegenerateLambda {
-                raw: query.lambda,
-            });
+            return Err(ArrowSpaceError::DegenerateLambda { raw: query.lambda });
         }
 
         if query.len() != self.nfeatures {
@@ -1542,11 +1550,7 @@ impl ArrowSpace {
         // Surface degenerate indexes at the point eps was chosen.
         // A significant fraction of ~0 raw lambdas means the graph Laplacian
         // maps every item to its null space — the index builds but is unusable.
-        let degenerate_count = self
-            .lambdas
-            .iter()
-            .filter(|&&l| l.abs() < 1e-12)
-            .count();
+        let degenerate_count = self.lambdas.iter().filter(|&&l| l.abs() < 1e-12).count();
         if degenerate_count > self.nitems / 2 {
             warn!(
                 "{} of {} lambdas are ~0 (degenerate). \

--- a/src/tests/test_clustering.rs
+++ b/src/tests/test_clustering.rs
@@ -16,6 +16,7 @@ use crate::{
 
 use log::debug;
 use serial_test::serial;
+use smartcore::linalg::basic::matrix::DenseMatrix;
 
 // -------------------- Helper function tests --------------------
 
@@ -118,7 +119,12 @@ fn test_intrinsic_dimension_line() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let id = builder.estimate_intrinsic_dimension(&rows, rows.len(), 3, 42);
+    let id = builder.estimate_intrinsic_dimension(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        3,
+        42,
+    );
 
     debug!("Estimated ID for 1D line: {}", id);
     assert!(id >= 1 && id <= 3, "Expected ID near 1, got {}", id);
@@ -134,7 +140,12 @@ fn test_intrinsic_dimension_plane() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let id = builder.estimate_intrinsic_dimension(&rows, rows.len(), 3, 42);
+    let id = builder.estimate_intrinsic_dimension(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        3,
+        42,
+    );
 
     debug!("Estimated ID for 2D plane: {}", id);
     assert!(id >= 1 && id <= 3, "Expected ID near 2, got {}", id);
@@ -154,7 +165,12 @@ fn test_intrinsic_dimension_full_space() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let id = builder.estimate_intrinsic_dimension(&rows, rows.len(), 5, 42);
+    let id = builder.estimate_intrinsic_dimension(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        5,
+        42,
+    );
 
     debug!("Estimated ID for 5D full space: {}", id);
     assert!(id >= 2 && id <= 5, "Expected ID near 5, got {}", id);
@@ -164,7 +180,8 @@ fn test_intrinsic_dimension_full_space() {
 fn test_intrinsic_dimension_small_n() {
     let rows = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
     let builder = ArrowSpaceBuilder::new();
-    let id = builder.estimate_intrinsic_dimension(&rows, 2, 2, 42);
+    let id =
+        builder.estimate_intrinsic_dimension(&DenseMatrix::from_2d_vec(&rows).unwrap(), 2, 2, 42);
     assert!(id <= 2);
 }
 
@@ -174,7 +191,8 @@ fn test_intrinsic_dimension_small_n() {
 fn test_step1_bounds_small_dataset() {
     let rows = vec![vec![1.0]; 10];
     let builder = ArrowSpaceBuilder::new();
-    let (k_min, k_max, _id) = builder.step1_bounds(&rows, 10, 1, None, 42);
+    let (k_min, k_max, _id) =
+        builder.step1_bounds(&DenseMatrix::from_2d_vec(&rows).unwrap(), 10, 1, None, 42);
 
     debug!("step 1 bounds (N=10, F=1): [{}, {}]", k_min, k_max);
     assert!(k_min >= 2, "k_min should be at least 2");
@@ -186,7 +204,8 @@ fn test_step1_bounds_small_dataset() {
 fn test_step1_bounds_large_n_small_f() {
     let rows = vec![vec![0.0; 5]; 1000];
     let builder = ArrowSpaceBuilder::new();
-    let (k_min, k_max, _id) = builder.step1_bounds(&rows, 1000, 5, None, 42);
+    let (k_min, k_max, _id) =
+        builder.step1_bounds(&DenseMatrix::from_2d_vec(&rows).unwrap(), 1000, 5, None, 42);
 
     debug!("step 1 bounds (N=1000, F=5): [{}, {}]", k_min, k_max);
     assert!(k_min <= k_max);
@@ -197,7 +216,8 @@ fn test_step1_bounds_large_n_small_f() {
 fn test_step1_bounds_high_dimensional() {
     let rows = vec![vec![0.0; 100]; 50];
     let builder = ArrowSpaceBuilder::new();
-    let (k_min, k_max, _id) = builder.step1_bounds(&rows, 50, 100, None, 42);
+    let (k_min, k_max, _id) =
+        builder.step1_bounds(&DenseMatrix::from_2d_vec(&rows).unwrap(), 50, 100, None, 42);
 
     debug!("step 1 bounds (N=50, F=100): [{}, {}]", k_min, k_max);
     assert!(k_min >= 2);
@@ -436,7 +456,13 @@ fn test_optimal_k_heuristic_synthetic_three_clusters() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, rows.len(), 3, None, 42);
+    let (k, radius, id) = builder.compute_optimal_k(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        3,
+        None,
+        42,
+    );
 
     debug!(
         "Optimal K={}, radius={:.6}, ID={} for 3-cluster synthetic",
@@ -474,7 +500,13 @@ fn test_optimal_k_heuristic_spherical_clusters() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, rows.len(), 2, None, 42);
+    let (k, radius, id) = builder.compute_optimal_k(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        2,
+        None,
+        42,
+    );
 
     debug!(
         "Optimal K={}, radius={:.6}, ID={} for 4 spherical clusters",
@@ -506,7 +538,13 @@ fn test_optimal_k_heuristic_high_dimensional_random() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, rows.len(), 8, None, 42);
+    let (k, radius, id) = builder.compute_optimal_k(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        8,
+        None,
+        42,
+    );
 
     debug!(
         "Optimal K={}, radius={:.6}, ID={} for 8D random",
@@ -528,7 +566,8 @@ fn test_optimal_k_heuristic_small_n() {
     ];
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, 4, 2, None, 42);
+    let (k, radius, id) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), 4, 2, None, 42);
 
     debug!("Optimal K={}, radius={:.6}, ID={} for N=4", k, radius, id);
     assert!(k >= 2, "K should be at least 2");
@@ -540,7 +579,8 @@ fn test_optimal_k_heuristic_small_n() {
 fn test_optimal_k_heuristic_degenerate_identical() {
     let rows = vec![vec![3.0, 4.0]; 100];
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, _id) = builder.compute_optimal_k(&rows, 100, 2, None, 42);
+    let (k, radius, _id) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), 100, 2, None, 42);
 
     debug!("Optimal K={}, radius={:.6} for identical points", k, radius);
     assert!(k >= 2, "K should be at least 2 even for degenerate data");
@@ -555,7 +595,8 @@ fn test_optimal_k_heuristic_single_feature() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, 100, 1, None, 42);
+    let (k, radius, id) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), 100, 1, None, 42);
 
     debug!(
         "Optimal K={}, radius={:.6}, ID={} for 1D uniform",
@@ -572,7 +613,8 @@ fn test_optimal_k_heuristic_single_feature() {
 fn test_optimal_k_minimum_viable_dataset() {
     let rows = vec![vec![0.0, 0.0], vec![1.0, 1.0]];
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, 2, 2, None, 42);
+    let (k, radius, id) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), 2, 2, None, 42);
 
     debug!("Optimal K={}, radius={:.6}, ID={} for N=2", k, radius, id);
     assert!(k >= 2, "K should be at least 2");
@@ -583,7 +625,13 @@ fn test_optimal_k_minimum_viable_dataset() {
 fn test_optimal_k_very_high_dimensional() {
     let rows = vec![vec![0.0; 1000]; 20];
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, 20, 1000, None, 42);
+    let (k, radius, id) = builder.compute_optimal_k(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        20,
+        1000,
+        None,
+        42,
+    );
 
     debug!(
         "Optimal K={}, radius={:.6}, ID={} for N=20, F=1000",
@@ -602,7 +650,8 @@ fn test_optimal_k_mixed_scale_features() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, _id) = builder.compute_optimal_k(&rows, 100, 2, None, 42);
+    let (k, radius, _id) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), 100, 2, None, 42);
 
     debug!(
         "Optimal K={}, radius={:.6} for mixed-scale features",
@@ -679,7 +728,8 @@ fn test_clustering_heuristic_trait_interface() {
     ];
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, 4, 2, None, 42);
+    let (k, radius, id) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), 4, 2, None, 42);
 
     debug!("Trait interface: K={}, radius={:.6}, ID={}", k, radius, id);
     assert!(k >= 2);
@@ -707,7 +757,13 @@ fn test_optimal_k_performance_large_dataset() {
 
     let builder = ArrowSpaceBuilder::new();
     let start = Instant::now();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, rows.len(), 4, None, 42);
+    let (k, radius, id) = builder.compute_optimal_k(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        4,
+        None,
+        42,
+    );
     let elapsed = start.elapsed();
 
     debug!(
@@ -750,8 +806,10 @@ fn test_consistent_results_with_seed() {
     let builder = ArrowSpaceBuilder::new();
 
     // --- A: Determinism — same seed must yield bit-identical results ---
-    let (k1, radius_1, id1) = builder.compute_optimal_k(&rows, n, f, None, 42);
-    let (k2, radius_2, id2) = builder.compute_optimal_k(&rows, n, f, None, 42);
+    let (k1, radius_1, id1) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), n, f, None, 42);
+    let (k2, radius_2, id2) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), n, f, None, 42);
 
     assert_eq!(k1, k2, "k must be identical across runs with the same seed");
     assert_eq!(
@@ -768,7 +826,8 @@ fn test_consistent_results_with_seed() {
     // --- B: Different seeds must produce the same k on well-separated data ---
     // The CH index is dominated by between-cluster variance here.
     // k=2 should win regardless of which random trials are used.
-    let (k3, _, _) = builder.compute_optimal_k(&rows, n, f, None, 99);
+    let (k3, _, _) =
+        builder.compute_optimal_k(&DenseMatrix::from_2d_vec(&rows).unwrap(), n, f, None, 99);
     assert_eq!(
         k1, k3,
         "k should be seed-stable on clearly separable data (got k={k1} vs k={k3})"
@@ -809,7 +868,13 @@ fn test_readme_example() {
     }
 
     let builder = ArrowSpaceBuilder::new();
-    let (k, radius, id) = builder.compute_optimal_k(&rows, rows.len(), 2, None, 42);
+    let (k, radius, id) = builder.compute_optimal_k(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        rows.len(),
+        2,
+        None,
+        42,
+    );
 
     debug!("README example: K={}, radius={:.6}, ID={}", k, radius, id);
     assert!(k >= 2, "Should detect at least 2 clusters");
@@ -1115,7 +1180,13 @@ fn test_step1_bounds_with_projection_basic() {
     let f = rows[0].len(); // 500
     let effective_dim = Some(50); // Simulates a JL projection from 500D → 50D
 
-    let (k_min, k_max, id_est) = builder.step1_bounds(&rows, n, f, effective_dim, 42);
+    let (k_min, k_max, id_est) = builder.step1_bounds(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        n,
+        f,
+        effective_dim,
+        42,
+    );
 
     // --- k_min ---
     // Formula: max(ceil(sqrt(n / 10.0)), 2)
@@ -1170,10 +1241,17 @@ fn test_step1_bounds_projection_dominates_over_ambient() {
     let f = rows[0].len();
 
     // Without projection: should cap f at 1000
-    let (_, k_max_no_proj, _) = builder.step1_bounds(&rows, n, f, None, 42);
+    let (_, k_max_no_proj, _) =
+        builder.step1_bounds(&DenseMatrix::from_2d_vec(&rows).unwrap(), n, f, None, 42);
 
     // With projection to 500D
-    let (_, k_max_with_proj, _) = builder.step1_bounds(&rows, n, f, Some(500), 42);
+    let (_, k_max_with_proj, _) = builder.step1_bounds(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        n,
+        f,
+        Some(500),
+        42,
+    );
 
     // Both should be bounded similarly (both use reasonable dims)
     // But with_proj uses 500*2=1000, no_proj uses min(f,1000)=1000
@@ -1198,7 +1276,13 @@ fn test_step1_bounds_small_effective_dim() {
     let f = rows[0].len();
     let effective_dim = Some(50); // Aggressive projection to 50D
 
-    let (k_min, k_max, _id_est) = builder.step1_bounds(&rows, n, f, effective_dim, 42);
+    let (k_min, k_max, _id_est) = builder.step1_bounds(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        n,
+        f,
+        effective_dim,
+        42,
+    );
 
     assert!(
         k_max >= 9,
@@ -1224,7 +1308,13 @@ fn test_step1_bounds_effective_dim_smaller_than_id() {
     let f = rows[0].len();
     let effective_dim = Some(50); // Projected to LESS than intrinsic dim
 
-    let (_k_min, k_max, id_est) = builder.step1_bounds(&rows, n, f, effective_dim, 42);
+    let (_k_min, k_max, id_est) = builder.step1_bounds(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        n,
+        f,
+        effective_dim,
+        42,
+    );
 
     // This tests over-compression: effective_dim < id_est
     // k_max candidates: [50*2=100, 2000/10=200, 5*id_est≈400, sqrt(2000)≈44]
@@ -1252,7 +1342,13 @@ fn test_step1_bounds_effective_dim_equals_intrinsic() {
     // Assume intrinsic dim ≈ 60, project to 120 (2× intrinsic)
     let effective_dim = Some(120);
 
-    let (_k_min, k_max, id_est) = builder.step1_bounds(&rows, n, f, effective_dim, 42);
+    let (_k_min, k_max, id_est) = builder.step1_bounds(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        n,
+        f,
+        effective_dim,
+        42,
+    );
 
     // k_max candidates: [120*2=240, 1000/10=100, 5*id_est≈300, sqrt(1000)≈31]
     // Expected: min(240, 100, 300, 31) = 31
@@ -1276,7 +1372,13 @@ fn test_step1_bounds_higher_effective_dim() {
     let f = rows[0].len(); // 500
     let effective_dim = Some(100); // Larger projection target than the basic test (50 → 100)
 
-    let (k_min, k_max, id_est) = builder.step1_bounds(&rows, n, f, effective_dim, 42);
+    let (k_min, k_max, id_est) = builder.step1_bounds(
+        &DenseMatrix::from_2d_vec(&rows).unwrap(),
+        n,
+        f,
+        effective_dim,
+        42,
+    );
 
     // --- k_min ---
     // Formula: max(ceil(sqrt(n / 10.0)), 2)


### PR DESCRIPTION
Fixes #31

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied

### Current behaviour
`build(rows)` cloned the dataset repeatedly before and during clustering:
- call-site `rows.clone()` into `start_clustering*` (rows unused afterwards)
- `ArrowSpace::new(rows.clone(), ..)` cloned again, then `DenseMatrix::from_2d_vec` copied a third time internally
- `start_clustering_dim_reduce` cloned `rows` once more when projection was skipped
- `start_clustering_dense` materialised a full `Vec<Vec<f64>>` (`compute`) out of the matrix just to feed heuristics
- persistence path built a temporary `ArrowSpace` from another `rows.clone()` only to save raw input
Meanwhile `aspace.data` already held exactly this data.

### New expected behaviour
Once `aspace` exists, all subsequent operations read `aspace.data` (the requested `self.compute_optimal_k(&aspace.data, ...)` shape):
- `compute_optimal_k`, `step1_bounds`, `estimate_intrinsic_dimension`, `run_incremental_clustering_with_sampling` take `&DenseMatrix<f64>`; row access via layout-safe `get_row(i).iterator(0)` views
- `ArrowSpace::new` consumes `items`, flattening once into a row-major matrix (no clone + copy)
- `start_clustering_dim_reduce` projects directly into a row-major `DenseMatrix`; no-projection branch uses `&aspace.data`
- `start_clustering_dense` moves rows in via `new_from_dense` (already zero-copy) and drops the `compute` materialisation
- raw-input persistence saves `&aspace.data` after Stage 1 — same file content, temp ArrowSpace removed

Seeds/sampling order untouched → clustering results are unchanged. Standard path: **3 dataset copies → 1**; dense path drops two more.

### Change logs

#### Changed
- `ClusteringHeuristic::compute_optimal_k` parameter type `&[Vec<f64>]` → `&DenseMatrix<f64>` (breaking for external trait implementors/callers; 0.x)
- builder clustering stages consume input data instead of cloning; heuristics/clustering read `aspace.data`
- patch version bump 0.26.9 → 0.26.10

#### Added
- test coverage updated: all `compute_optimal_k`/`step1_bounds`/`estimate_intrinsic_dimension` call sites in `test_clustering.rs` exercise the new signatures