### PR TITLE
docs: add AGENTS.md with core design invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md — Design Invariants
+
+Normative constraints for any modification to this crate. Workflow guidance and
+license acceptance live in [CONTRIBUTING.md](CONTRIBUTING.md). A change that
+violates an invariant here must be rejected regardless of its local merits.
+
+Design background: *The ArrowSpace Algorithm: From Graph Wiring to τ-Mode
+Spectral Search* — L. Moriondo, DOI
+[10.5281/zenodo.21679021](https://zenodo.org/records/21679021).
+
+## 1. The graph Laplacian is the centerpiece
+
+Every capability — search, clustering, partitioning, sequencing, analysis,
+compression — MUST derive from the feature-space graph Laplacian built by the
+pipeline (`GraphLaplacian.matrix`: L = D − A, its weights, and per-node λτ
+read-outs). Do not introduce parallel data paths that bypass it.
+
+- Lives in: `src/graph.rs` (`GraphLaplacian`), `src/laplacian.rs` (construction)
+- Violation example: computing similarity structures from raw vectors when the
+  adjacency recoverable from L already encodes them.
+
+## 2. Discrete spaces only
+
+Arrowspace computes in discrete spaces. NEVER use eigensolvers, continuous
+optimisation or dense spectral embeddings. Spectral quantities are per-node
+Rayleigh quotients (λ) computed by graph–vector products; structural ordering
+problems are solved combinatorially on the graph.
+
+- Lives in: `src/search/taumode.rs` (λτ read-out)
+- Violation example: a Fiedler-vector ordering via Lanczos/power iteration,
+  or any call into an eigen-decomposition routine.
+
+## 3. Sparse-first, flat-first
+
+Keep data sparse (`sprs::CsMat`) and memory flat (contiguous `Vec` /
+row-major `DenseMatrix`). Never densify N×N or N×F structures beyond bounded
+sizes; never route hot paths through hash maps where sorted arrays suffice.
+Dense buffers must be row-major so rows are addressable as contiguous slices.
+
+- Lives in: `src/laplacian.rs` (CSR assembly), `src/core.rs`
+  (`ArrowSpace::new` single-flatten); see issues #107 and #31 for the
+  DashMap→sort-merge and clone-removal precedents.
+- Violation example: an O(N·E) map scan, or cloning the dataset between
+  pipeline stages that could share one owned buffer.
+
+## 4. Determinism by construction
+
+Identical inputs MUST produce identical outputs. Every randomised stage takes
+an explicit seed; tie-breaking in sorts, heaps and merges is explicit;
+parallel reductions merge deterministically (e.g. max-weight).
+
+- Lives in: `src/clustering/mod.rs` (seeded StdRng), `src/laplacian.rs`
+  (deterministic symmetrisation).
+- Violation example: relying on HashMap iteration order or last-write-wins
+  concurrent updates to resolve conflicting values.
+
+## 5. Pipeline separation
+
+The build pipeline is clustering → sampling → Laplacian construction → score
+read-out. New capabilities plug into the final read-out slot and MUST NOT
+reach backwards into earlier stages or mutate their inputs.
+
+- Lives in: `src/builder.rs` (stage structure), `src/maps/eigenmaps.rs`
+  (read-out traits).
+- Violation example: a search feature that re-runs kNN inside the query path.


### PR DESCRIPTION
Fixes #133 (prerequisite groundwork; see note below)

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied

### Current behaviour
The crate's non-negotiable design rules existed only in conversation and code-review history. Nothing told an automated harness or a new contributor that, e.g., eigensolvers are banned or that every capability must derive from the graph Laplacian.

### New expected behaviour
`AGENTS.md` at the repo root codifies five normative design invariants for any implementation work:

1. **The graph Laplacian is the centerpiece** — capabilities derive from `GraphLaplacian.matrix` (L = D − A) and its λτ read-outs
2. **Discrete spaces only** — no eigensolvers, continuous optimisation or dense spectral embeddings
3. **Sparse-first, flat-first** — `CsMat` + contiguous row-major buffers; no hot-path hash maps (per #107/#31 precedents)
4. **Determinism by construction** — explicit seeds, explicit tie-breaking
5. **Pipeline separation** — clustering → sampling → Laplacian → score read-out; no reaching backwards

Each invariant carries a rationale, a code pointer (`src/graph.rs`, `src/laplacian.rs`, `src/search/taumode.rs`, ...) and a concrete violation example. Workflow guidance and license terms remain in `CONTRIBUTING.md`, which is unchanged. Design background links the paper: *The ArrowSpace Algorithm: From Graph Wiring to τ-Mode Spectral Search*, DOI 10.5281/zenodo.21679021.

Docs-only change: no version bump, no source files touched.

### Change logs

#### Added
- `AGENTS.md`: design-invariant charter for code work (agents and humans), referenced by future feature PRs (e.g. sequencing #133)