### PR TITLE
feat(analysis): eigensolver-free sequencing via MST-chain seriation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.26.10"
+version = "0.26.11"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.26.10"
+version = "0.26.11"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/examples/02_proteins_lookup.rs
+++ b/examples/02_proteins_lookup.rs
@@ -16,8 +16,8 @@
 // Dependencies: arrowspace crate in this repo.
 // Run: cargo run --example proteins_lookup
 
-use ordered_float::OrderedFloat;
 use arrowspace::builder::ArrowSpaceBuilder;
+use ordered_float::OrderedFloat;
 use std::collections::BTreeMap;
 
 #[path = "./common/lib.rs"]
@@ -107,11 +107,11 @@ fn main() {
     //   k: optional cap on neighbors per item
     //   p: kernel exponent
     //   sigma_override: None => σ defaults to eps
-    let eps = 0.05;        // Larger epsilon for more connected graph
-    let k = 12usize;       // More neighbors for stability (trade-off with items)
+    let eps = 0.05; // Larger epsilon for more connected graph
+    let k = 12usize; // More neighbors for stability (trade-off with items)
     let topk = 4usize;
-    let p = 2.0;           // Linear kernel less sensitive to outliers  
-    let sigma_override = Some(eps * 0.5);  // Explicit sigma control
+    let p = 2.0; // Linear kernel less sensitive to outliers  
+    let sigma_override = Some(eps * 0.5); // Explicit sigma control
 
     let (aspace, _) = ArrowSpaceBuilder::new()
         .with_lambda_graph(eps, k, topk, p, sigma_override)
@@ -132,9 +132,9 @@ fn main() {
         zset.zadd(lambdas[i], i, id.clone(), items_nxf[i].clone());
     }
 
-    // 5) Query λ for the query vector 
+    // 5) Query λ for the query vector
     // define a band of querying arond the query vector
-    
+
     let lambda_q = lambdas[q_index];
     let band = std_deviation(&lambdas).unwrap() as f64 / 2.0_f64.powf(p);
     let lo = lambda_q - band;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -4,4 +4,5 @@
 //! * Motives spotting
 
 pub mod motives;
+pub mod sequencing;
 pub mod subgraphs;

--- a/src/analysis/motives.rs
+++ b/src/analysis/motives.rs
@@ -596,13 +596,13 @@ impl Motives for GraphLaplacian {
             return false;
         }
         // Parallel short-circuit check
-        let ok = set.par_iter().all(|&u| {
+
+        set.par_iter().all(|&u| {
             let nbrs: HashSet<usize> = self.neighbors_of(u).iter().map(|(j, _)| *j).collect();
             let need = sz - 1;
             let have = nbrs.intersection(set).count();
             have == need
-        });
-        ok
+        })
     }
 
     /// unused: potential improvements using rayleigh energy boundaries
@@ -667,7 +667,7 @@ fn triangle_stats_sorted(neigh_idx: &[Vec<usize>], n: usize) -> (Vec<usize>, Vec
 
 // Count common neighbors excluding i and j using two-pointer scan on sorted lists
 #[inline]
-fn count_intersection(a: &Vec<usize>, b: &Vec<usize>, i: usize, j: usize) -> usize {
+fn count_intersection(a: &[usize], b: &[usize], i: usize, j: usize) -> usize {
     let mut x = 0usize;
     let (mut p, mut q) = (0usize, 0usize);
     while p < a.len() && q < b.len() {
@@ -690,7 +690,7 @@ fn count_intersection(a: &Vec<usize>, b: &Vec<usize>, i: usize, j: usize) -> usi
 
 // Count edges among s_nbrs after position start by intersecting with neigh(u)
 #[inline]
-fn count_edges_among(neigh_u: &Vec<usize>, s_nbrs: &Vec<usize>, start: usize) -> usize {
+fn count_edges_among(neigh_u: &[usize], s_nbrs: &[usize], start: usize) -> usize {
     let mut x = 0usize;
     let mut p = 0usize;
     let mut q = start;

--- a/src/analysis/sequencing.rs
+++ b/src/analysis/sequencing.rs
@@ -181,6 +181,11 @@ pub fn sequence_by_graph(gl: &GraphLaplacian) -> Sequence {
 
 /// Extracts the undirected weighted adjacency implied by L = D − A as
 /// flat per-node neighbour lists (sorted by neighbour index).
+///
+/// Assumes L is symmetric: each undirected edge is read once from the upper
+/// triangle (`j > i`). The pipeline guarantees this via deterministic
+/// symmetrisation; hand-built Laplacians must be symmetrised first or
+/// edges present only below the diagonal will be missed.
 fn _adjacency_from_laplacian(l: &CsMat<f64>) -> Vec<Vec<(usize, OrderedFloat<f64>)>> {
     let n = l.shape().0;
 
@@ -256,7 +261,8 @@ fn _minimum_spanning_forest(
 fn _serialise_forest(tree: Vec<Vec<usize>>) -> Sequence {
     let n = tree.len();
 
-    // Component labelling by stack DFS.
+    // Component labelling by stack DFS; members kept sorted ascending so
+    // downstream scans and tie-breaks are index-deterministic.
     let mut comp_of = vec![usize::MAX; n];
     let mut components: Vec<Vec<usize>> = Vec::new();
     for s in 0..n {
@@ -276,25 +282,27 @@ fn _serialise_forest(tree: Vec<Vec<usize>>) -> Sequence {
                 }
             }
         }
+        members.sort_unstable();
         components.push(members);
     }
 
     // Larger components first; ties broken by smallest member index.
-    components.sort_unstable_by_key(|members| {
-        let min_idx = members.iter().copied().min().unwrap_or(usize::MAX);
-        (std::cmp::Reverse(members.len()), min_idx)
-    });
+    components.sort_unstable_by_key(|members| (std::cmp::Reverse(members.len()), members[0]));
 
     let mut order: Vec<usize> = Vec::with_capacity(n);
     let mut depth_of = vec![0f64; n];
     let mut visited = vec![false; n];
+    // Scratch buffers reused by both sweeps of every component; entries are
+    // reset per call so cost stays proportional to the component, not n.
+    let mut dist = vec![usize::MAX; n];
+    let mut seen = vec![false; n];
 
     for members in &components {
-        let seed = members.iter().copied().min().unwrap_or(members[0]);
+        let seed = members[0];
 
         // Double sweep: BFS farthest twice to land near a tree diameter end.
-        let (far, _) = _bfs_farthest(seed, &tree);
-        let (root, _) = _bfs_farthest(far, &tree);
+        let far = _bfs_farthest(seed, &tree, members, &mut dist, &mut seen);
+        let root = _bfs_farthest(far, &tree, members, &mut dist, &mut seen);
 
         // Iterative DFS preorder; children pushed in reverse so the
         // smallest index is visited first.
@@ -319,13 +327,23 @@ fn _serialise_forest(tree: Vec<Vec<usize>>) -> Sequence {
     }
 }
 
-/// BFS over the tree returning the farthest node reachable from `src`;
-/// distance ties break on the smaller node index.
-fn _bfs_farthest(src: usize, tree: &[Vec<usize>]) -> (usize, usize) {
-    let n = tree.len();
-    let mut dist = vec![usize::MAX; n];
-    let mut seen = vec![false; n];
-    let mut queue = VecDeque::with_capacity(n);
+/// BFS over a component's tree returning the farthest member from `src`;
+/// distance ties break on the smaller node index (`members` is ascending).
+/// `dist` and `seen` are caller-owned scratch buffers reset for `members`
+/// only, so each call costs O(|members| + edges within the component) and
+/// the total across all components stays O(V + E).
+fn _bfs_farthest(
+    src: usize,
+    tree: &[Vec<usize>],
+    members: &[usize],
+    dist: &mut [usize],
+    seen: &mut [bool],
+) -> usize {
+    for &m in members {
+        dist[m] = usize::MAX;
+        seen[m] = false;
+    }
+    let mut queue = VecDeque::with_capacity(members.len());
     dist[src] = 0;
     seen[src] = true;
     queue.push_back(src);
@@ -340,13 +358,15 @@ fn _bfs_farthest(src: usize, tree: &[Vec<usize>]) -> (usize, usize) {
         }
     }
 
+    // Every member is reachable within its own tree, so no MAX guard is
+    // needed; strict > keeps the first (smallest) index on ties.
     let mut best = src;
     let mut best_dist = 0;
-    for (u, &d) in dist.iter().enumerate() {
-        if d != usize::MAX && d > best_dist {
+    for &u in members {
+        if dist[u] > best_dist {
             best = u;
-            best_dist = d;
+            best_dist = dist[u];
         }
     }
-    (best, best_dist)
+    best
 }

--- a/src/analysis/sequencing.rs
+++ b/src/analysis/sequencing.rs
@@ -1,0 +1,352 @@
+//! Sequencing: total orderings over the nodes of the feature-space graph Laplacian.
+//!
+//! Sequencing assigns each node of `GraphLaplacian.matrix` (L = D − A) a discrete
+//! position along a path through the graph, producing a permutation usable for
+//! data curricula, de-duplication sweeps or coherent walk generation.
+//!
+//! Following the design invariants (`AGENTS.md`), sequencing is computed with
+//! purely combinatorial graph algorithms — no eigensolvers, no continuous
+//! embeddings. Two strategies are provided:
+//!
+//! * [`sequence_by_lambda`] orders nodes by their per-node λ score: a "spectral
+//!   curriculum" from low to high Rayleigh energy (or the reverse).
+//! * [`sequence_by_graph`] performs MST-chain seriation: a minimum spanning
+//!   forest is grown over the weighted adjacency recovered from L (A = D − L),
+//!   then each tree is walked in depth-first preorder from an approximate
+//!   diameter endpoint found by double-sweep BFS. This is the discrete
+//!   counterpart of Fiedler-vector seriation: it approximates a minimum linear
+//!   arrangement without computing any vector.
+//!
+//! Reference: *The ArrowSpace Algorithm: From Graph Wiring to τ-Mode Spectral
+//! Search*, DOI [10.5281/zenodo.21679021](https://zenodo.org/records/21679021).
+//!
+//! # Examples
+//!
+//! ```
+//! use arrowspace::analysis::sequencing::{sequence_by_graph, sequence_by_lambda};
+//!
+//! // λ-based curriculum ordering over per-node scores.
+//! let seq = sequence_by_lambda(&[0.9, 0.1, 0.4], false);
+//! assert_eq!(seq.order, vec![1, 2, 0]);
+//!
+//! // Graph seriation over a Laplacian built from items.
+//! use arrowspace::graph::GraphParams;
+//! use arrowspace::laplacian::build_laplacian_matrix;
+//! use smartcore::linalg::basic::arrays::Array2;
+//! use smartcore::linalg::basic::matrix::DenseMatrix;
+//!
+//! let items = vec![
+//!     vec![1.0, 0.0, 0.0],
+//!     vec![0.9, 0.1, 0.0],
+//!     vec![0.8, 0.6, 0.0],
+//!     vec![0.0, 1.0, 0.0],
+//!     vec![0.1, 0.9, 0.0],
+//! ];
+//! let params = GraphParams {
+//!     eps: 0.5,
+//!     k: 3,
+//!     topk: 3,
+//!     p: 2.0,
+//!     sigma: Some(0.1),
+//!     normalise: true,
+//!     sparsity_check: false,
+//! };
+//! let gl = build_laplacian_matrix(
+//!     DenseMatrix::<f64>::from_2d_vec(&items).unwrap().transpose(),
+//!     &params,
+//!     None,
+//!     false,
+//! );
+//! let seq = sequence_by_graph(&gl);
+//! assert_eq!(seq.order.len(), gl.matrix.shape().0);
+//! ```
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, VecDeque};
+
+use log::{debug, info};
+use ordered_float::OrderedFloat;
+
+use crate::graph::GraphLaplacian;
+use sprs::CsMat;
+
+/// A total order over the nodes of a graph Laplacian.
+#[derive(Clone, Debug)]
+pub struct Sequence {
+    /// Node indices in sequence order: a permutation of `0..n_nodes`.
+    pub order: Vec<usize>,
+    /// Discrete coordinate per sequence step, aligned with `order`:
+    /// the λ score for [`sequence_by_lambda`], or the DFS discovery depth
+    /// within its component for [`sequence_by_graph`].
+    pub positions: Vec<f64>,
+    /// Number of connected components traversed (`1` for λ orderings).
+    pub components: usize,
+}
+
+/// Orders items by their per-node λ scores in ascending or descending order.
+///
+/// This is the simplest sequencing strategy: a spectral curriculum that walks
+/// items from low Rayleigh energy to high (ascending), or the reverse. Ties
+/// break on ascending node index; the result is fully deterministic.
+///
+/// # Panics
+///
+/// Panics if `lambdas` contains fewer than two items.
+pub fn sequence_by_lambda(lambdas: &[f64], descending: bool) -> Sequence {
+    assert!(
+        lambdas.len() >= 2,
+        "sequencing requires at least two items, got {}",
+        lambdas.len()
+    );
+
+    let mut order: Vec<usize> = (0..lambdas.len()).collect();
+    if descending {
+        order.sort_unstable_by(|&a, &b| {
+            lambdas[b]
+                .partial_cmp(&lambdas[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+    } else {
+        order.sort_unstable_by(|&a, &b| {
+            lambdas[a]
+                .partial_cmp(&lambdas[b])
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+    }
+
+    debug!(
+        "sequence_by_lambda ordered {} items ({})",
+        order.len(),
+        if descending {
+            "descending"
+        } else {
+            "ascending"
+        }
+    );
+
+    let positions = order.iter().map(|&i| lambdas[i]).collect();
+    Sequence {
+        order,
+        positions,
+        components: 1,
+    }
+}
+
+/// Serialises the nodes of a graph Laplacian by walking its minimum spanning
+/// forest in depth-first preorder from approximate diameter endpoints.
+///
+/// The adjacency is recovered exactly from the Laplacian (`A[i,j] = -L[i,j]`
+/// off-diagonal); no similarity recomputation happens here. Each connected
+/// component yields one contiguous block of the sequence; blocks are ordered
+/// by descending size, ties by ascending smallest member index. Within a
+/// block, the walk starts at a double-sweep BFS endpoint and always visits
+/// smaller-indexed children first, so the output is deterministic.
+///
+/// Positions report the DFS discovery depth of each node within its component.
+///
+/// Complexity: `O(E log V + V)` time, `O(V + E)` space.
+///
+/// # Panics
+///
+/// Panics if the Laplacian has fewer than two nodes or is not square.
+pub fn sequence_by_graph(gl: &GraphLaplacian) -> Sequence {
+    let n = gl.matrix.shape().0;
+    assert!(n >= 2, "sequencing requires at least two nodes, got {}", n);
+    assert_eq!(
+        gl.matrix.shape().1,
+        n,
+        "the laplacian must be a square matrix"
+    );
+
+    info!("Sequencing {} laplacian nodes via MST-chain seriation", n);
+
+    let adjacency = _adjacency_from_laplacian(&gl.matrix);
+    debug!(
+        "Recovered undirected adjacency with {} nodes",
+        adjacency.len()
+    );
+
+    let forest = _minimum_spanning_forest(&adjacency, n);
+    let sequence = _serialise_forest(forest);
+
+    info!(
+        "Sequenced {} nodes across {} component(s)",
+        sequence.order.len(),
+        sequence.components
+    );
+    sequence
+}
+
+/// Extracts the undirected weighted adjacency implied by L = D − A as
+/// flat per-node neighbour lists (sorted by neighbour index).
+fn _adjacency_from_laplacian(l: &CsMat<f64>) -> Vec<Vec<(usize, OrderedFloat<f64>)>> {
+    let n = l.shape().0;
+
+    // Off-diagonal entries of L are -w; take each edge once from its upper
+    // triangle, then emit both directions for flat sort-merge grouping.
+    let mut directed: Vec<(usize, usize, OrderedFloat<f64>)> = Vec::new();
+    for (i, row) in l.outer_iterator().enumerate() {
+        for (j, &v) in row.iter() {
+            if j > i && v < 0.0 {
+                let w = OrderedFloat(-v);
+                directed.push((i, j, w));
+                directed.push((j, i, w));
+            }
+        }
+    }
+    directed.sort_unstable_by_key(|&(i, j, _)| (i, j));
+
+    let mut adjacency: Vec<Vec<(usize, OrderedFloat<f64>)>> = vec![Vec::new(); n];
+    let mut last = (usize::MAX, usize::MAX);
+    for &(i, j, w) in &directed {
+        if (i, j) != last {
+            adjacency[i].push((j, w));
+            last = (i, j);
+        }
+    }
+    adjacency
+}
+
+/// Prim's algorithm grown from every unvisited node in index order, producing
+/// a spanning *forest* whose trees span the graph's connected components.
+/// Heap entries carry `(weight, candidate, parent)` so pops resolve weight
+/// ties deterministically by node index.
+fn _minimum_spanning_forest(
+    adjacency: &[Vec<(usize, OrderedFloat<f64>)>],
+    n: usize,
+) -> Vec<Vec<usize>> {
+    let mut tree: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut in_tree = vec![false; n];
+    let mut heap: BinaryHeap<Reverse<(OrderedFloat<f64>, usize, usize)>> = BinaryHeap::new();
+
+    for start in 0..n {
+        if in_tree[start] {
+            continue;
+        }
+        in_tree[start] = true;
+        for &(j, w) in &adjacency[start] {
+            heap.push(Reverse((w, j, start)));
+        }
+        while let Some(Reverse((_, j, parent))) = heap.pop() {
+            if in_tree[j] {
+                continue;
+            }
+            in_tree[j] = true;
+            tree[parent].push(j);
+            tree[j].push(parent);
+            for &(k, wk) in &adjacency[j] {
+                if !in_tree[k] {
+                    heap.push(Reverse((wk, k, j)));
+                }
+            }
+        }
+    }
+
+    // Ascending child lists make every downstream walk deterministic.
+    for neighbours in &mut tree {
+        neighbours.sort_unstable();
+    }
+    tree
+}
+
+/// Labels the forest's trees, orders them by (size desc, min index asc),
+/// roots each at a double-sweep BFS endpoint and concatenates DFS preorders.
+fn _serialise_forest(tree: Vec<Vec<usize>>) -> Sequence {
+    let n = tree.len();
+
+    // Component labelling by stack DFS.
+    let mut comp_of = vec![usize::MAX; n];
+    let mut components: Vec<Vec<usize>> = Vec::new();
+    for s in 0..n {
+        if comp_of[s] != usize::MAX {
+            continue;
+        }
+        let id = components.len();
+        let mut members = Vec::new();
+        let mut stack = vec![s];
+        comp_of[s] = id;
+        while let Some(u) = stack.pop() {
+            members.push(u);
+            for &v in &tree[u] {
+                if comp_of[v] == usize::MAX {
+                    comp_of[v] = id;
+                    stack.push(v);
+                }
+            }
+        }
+        components.push(members);
+    }
+
+    // Larger components first; ties broken by smallest member index.
+    components.sort_unstable_by_key(|members| {
+        let min_idx = members.iter().copied().min().unwrap_or(usize::MAX);
+        (std::cmp::Reverse(members.len()), min_idx)
+    });
+
+    let mut order: Vec<usize> = Vec::with_capacity(n);
+    let mut depth_of = vec![0f64; n];
+    let mut visited = vec![false; n];
+
+    for members in &components {
+        let seed = members.iter().copied().min().unwrap_or(members[0]);
+
+        // Double sweep: BFS farthest twice to land near a tree diameter end.
+        let (far, _) = _bfs_farthest(seed, &tree);
+        let (root, _) = _bfs_farthest(far, &tree);
+
+        // Iterative DFS preorder; children pushed in reverse so the
+        // smallest index is visited first.
+        let mut stack = vec![(root, 0usize)];
+        visited[root] = true;
+        while let Some((u, depth)) = stack.pop() {
+            order.push(u);
+            depth_of[u] = depth as f64;
+            for &v in tree[u].iter().rev() {
+                if !visited[v] {
+                    visited[v] = true;
+                    stack.push((v, depth + 1));
+                }
+            }
+        }
+    }
+
+    Sequence {
+        positions: order.iter().map(|&u| depth_of[u]).collect(),
+        order,
+        components: components.len(),
+    }
+}
+
+/// BFS over the tree returning the farthest node reachable from `src`;
+/// distance ties break on the smaller node index.
+fn _bfs_farthest(src: usize, tree: &[Vec<usize>]) -> (usize, usize) {
+    let n = tree.len();
+    let mut dist = vec![usize::MAX; n];
+    let mut seen = vec![false; n];
+    let mut queue = VecDeque::with_capacity(n);
+    dist[src] = 0;
+    seen[src] = true;
+    queue.push_back(src);
+
+    while let Some(u) = queue.pop_front() {
+        for &v in &tree[u] {
+            if !seen[v] {
+                seen[v] = true;
+                dist[v] = dist[u] + 1;
+                queue.push_back(v);
+            }
+        }
+    }
+
+    let mut best = src;
+    let mut best_dist = 0;
+    for (u, &d) in dist.iter().enumerate() {
+        if d != usize::MAX && d > best_dist {
+            best = u;
+            best_dist = d;
+        }
+    }
+    (best, best_dist)
+}

--- a/src/analysis/subgraphs/sg_from_centroids.rs
+++ b/src/analysis/subgraphs/sg_from_centroids.rs
@@ -28,7 +28,7 @@ impl SubgraphsCentroid for GraphLaplacian {
             params.max_depth, params.min_centroids
         );
 
-        let hierarchy = CentroidHierarchy::from_centroid_graph(aspace, self, &params);
+        let hierarchy = CentroidHierarchy::from_centroid_graph(aspace, self, params);
 
         let subgraphs = hierarchy.all_subgraphs();
 
@@ -244,10 +244,10 @@ fn build_root_indices_from_centroid_map(aspace: &ArrowSpace, n_root: usize) -> V
     } else if !aspace.cluster_assignments.is_empty() {
         // Fallback: cluster_assignments (Vec<Option<usize>>).
         for (item_idx, &assignment) in aspace.cluster_assignments.iter().enumerate() {
-            if let Some(cid) = assignment {
-                if cid < n_root {
-                    root_indices[cid].push(item_idx);
-                }
+            if let Some(cid) = assignment
+                && cid < n_root
+            {
+                root_indices[cid].push(item_idx);
             }
             // Ignore items with assignment == None (outliers / unassigned).
         }
@@ -304,16 +304,12 @@ pub(crate) fn recluster_centroids(
     }
 
     let k_eff = k.min(n);
-    let mut labels = vec![0usize; n];
-    for i in 0..n {
-        labels[i] = i % k_eff;
-    }
+    let labels: Vec<usize> = (0..n).map(|i| i % k_eff).collect();
 
     let mut sums = DenseMatrix::zeros(k_eff, d);
     let mut counts = vec![0usize; k_eff];
 
-    for i in 0..n {
-        let cid = labels[i];
+    for (i, &cid) in labels.iter().enumerate() {
         counts[cid] += 1;
         for j in 0..d {
             let val = *centroids.get((i, j));
@@ -322,9 +318,9 @@ pub(crate) fn recluster_centroids(
         }
     }
 
-    for cid in 0..k_eff {
-        if counts[cid] > 0 {
-            let c = counts[cid] as f64;
+    for (cid, &count) in counts.iter().enumerate() {
+        if count > 0 {
+            let c = count as f64;
             for j in 0..d {
                 let cur = *sums.get((cid, j));
                 sums.set((cid, j), cur / c);

--- a/src/analysis/subgraphs/sg_from_motives.rs
+++ b/src/analysis/subgraphs/sg_from_motives.rs
@@ -125,7 +125,7 @@ impl SubgraphsMotive for GraphLaplacian {
         );
 
         // 1. Run energy motif detection (subcentroid space → item space).
-        let item_motifs: Vec<Vec<usize>> = self.spot_motives_energy(&aspace, &cfg.motives);
+        let item_motifs: Vec<Vec<usize>> = self.spot_motives_energy(aspace, &cfg.motives);
 
         info!(
             "Motif detection returned {} item-space candidates",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -189,7 +189,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
                 n_items,
                 n_features,
                 None,
-                self.clustering_seed.as_ref().unwrap().clone(),
+                *self.clustering_seed.as_ref().unwrap(),
             );
 
             debug!(
@@ -357,7 +357,13 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
         // STAGE 4: Compute Optimal K (now operating on reduced-dim data)
         // Auto-compute optimal clustering parameters via heuristic
         info!("Computing optimal clustering parameters");
-        let (k_opt, radius, intrinsic_dim) = if self.cluster_max_clusters.is_none() {
+        let (k_opt, radius, intrinsic_dim) = if let Some(manual_k) = self.cluster_max_clusters {
+            info!(
+                "Using manual override (no intrinsic dimensions): K={:?}, radius={:.4}",
+                self.cluster_max_clusters, self.cluster_radius
+            );
+            (manual_k, self.cluster_radius, None)
+        } else {
             if self.clustering_seed.is_none() {
                 panic!("`self.clustering_seed` shoud be set for optimal k heuristics")
             }
@@ -367,22 +373,12 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
                 n_items,
                 n_features,
                 Some(reduced_dim),
-                self.clustering_seed.as_ref().unwrap().clone(),
+                *self.clustering_seed.as_ref().unwrap(),
             );
             debug!("Heuristic K={}, radius={:.4}", k_opt, radius);
             self.cluster_max_clusters = Some(k_opt);
             self.cluster_radius = radius;
             (k_opt, radius, Some(intrinsic_dim))
-        } else {
-            info!(
-                "Using manual override (no intrinsic dimensions): K={:?}, radius={:.4}",
-                self.cluster_max_clusters, self.cluster_radius
-            );
-            (
-                self.cluster_max_clusters.clone().unwrap(),
-                self.cluster_radius,
-                None,
-            )
         };
 
         debug!(
@@ -432,7 +428,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
             centroids: clustered_dm,
             reduced_dim,
             n_items,
-            n_features: n_features, // Keep original count for metadata
+            n_features, // Keep original count for metadata
         }
     }
 
@@ -498,7 +494,7 @@ impl ClusteringHeuristic for ArrowSpaceBuilder {
                 n_items,
                 n_features,
                 None,
-                self.clustering_seed.as_ref().unwrap().clone(),
+                *self.clustering_seed.as_ref().unwrap(),
             );
 
             debug!(
@@ -612,21 +608,22 @@ impl ArrowSpaceBuilder {
 
     /// copy all the static parameters to generate a similar builder from the original
     pub fn copy_params(&self) -> Self {
-        let mut result = Self::default();
-        result.prebuilt_spectral = self.prebuilt_spectral;
-        result.synthesis = self.synthesis;
-        result.lambda_eps = self.lambda_eps;
-        result.lambda_k = self.lambda_k;
-        result.lambda_topk = self.lambda_topk;
-        result.lambda_p = self.lambda_p;
-        result.lambda_sigma = self.lambda_sigma;
-        result.normalise = self.normalise;
-        result.sparsity_check = self.sparsity_check;
-        result.sampling = self.sampling.clone();
-        result.use_dims_reduction = self.use_dims_reduction;
-        result.rp_eps = self.rp_eps;
-        result.persistence = self.persistence.clone();
-        result
+        Self {
+            prebuilt_spectral: self.prebuilt_spectral,
+            synthesis: self.synthesis,
+            lambda_eps: self.lambda_eps,
+            lambda_k: self.lambda_k,
+            lambda_topk: self.lambda_topk,
+            lambda_p: self.lambda_p,
+            lambda_sigma: self.lambda_sigma,
+            normalise: self.normalise,
+            sparsity_check: self.sparsity_check,
+            sampling: self.sampling.clone(),
+            use_dims_reduction: self.use_dims_reduction,
+            rp_eps: self.rp_eps,
+            persistence: self.persistence.clone(),
+            ..Self::default()
+        }
     }
 
     // -------------------- Lambda-graph configuration --------------------
@@ -752,7 +749,7 @@ impl ArrowSpaceBuilder {
     ///
     /// # Arguments
     /// * `radius` - Squared L2 distance threshold for cluster creation.
-    ///              Typical range: [0.5, 2.0]
+    ///   Typical range: [0.5, 2.0]
     ///
     /// # Example
     /// ```ignore
@@ -1017,7 +1014,7 @@ impl ArrowSpaceBuilder {
                 use crate::storage::parquet::{save_arrowspace, save_lambda_with_builder};
 
                 // save the metadata needed for search operations
-                let stored = save_arrowspace(&aspace, path.clone(), &name);
+                let stored = save_arrowspace(&aspace, path.clone(), name);
 
                 match stored {
                     Ok(_) => debug!("{}-arrowspace saved", name),
@@ -1585,7 +1582,7 @@ impl ConfigValue {
     // Convenience extraction methods
     pub fn as_tau_mode(&self) -> Option<TauMode> {
         match self {
-            ConfigValue::TauMode(v) => Some(v.clone()),
+            ConfigValue::TauMode(v) => Some(*v),
             _ => None,
         }
     }

--- a/src/clustering/mod.rs
+++ b/src/clustering/mod.rs
@@ -337,11 +337,10 @@ pub trait ClusteringHeuristic {
                         _ => k_a.cmp(k_b),
                     }
                 })
+                && fine_score > best_score
             {
-                if fine_score > best_score {
-                    best_k = fine_k;
-                    best_score = fine_score;
-                }
+                best_k = fine_k;
+                best_score = fine_score;
             }
         }
 
@@ -551,8 +550,7 @@ pub fn kmeans_lloyd(rows: &[Vec<f64>], k: usize, max_iter: usize, seed: u64) -> 
     let k = k.min(n);
 
     // Flatten row-major data
-    let x: DenseMatrix<f64> =
-        DenseMatrix::from_iterator(rows.into_iter().flatten().map(|x| *x), n, f, 1);
+    let x: DenseMatrix<f64> = DenseMatrix::from_iterator(rows.iter().flatten().copied(), n, f, 1);
 
     // Create parameters with explicit seed
     let params = KMeansParameters {
@@ -565,9 +563,8 @@ pub fn kmeans_lloyd(rows: &[Vec<f64>], k: usize, max_iter: usize, seed: u64) -> 
     let km = KMeans::fit(&x, params).expect("Failed to fit K-Means model");
 
     // Predict cluster assignments
-    let labels = km.predict(&x).expect("Failed to predict labels");
 
-    labels
+    km.predict(&x).expect("Failed to predict labels")
 }
 
 pub fn euclidean_dist(a: &[f64], b: &[f64]) -> f64 {
@@ -904,8 +901,8 @@ pub(crate) fn run_incremental_clustering_with_sampling(
             "Centroids:  {:?}\n : nitems->{} nfeatures->{}",
             flat, x_out, nfeatures
         );
-        let dm = DenseMatrix::from_iterator(flat.iter().map(|x| *x), *x_out, nfeatures, 1);
-        dm
+
+        DenseMatrix::from_iterator(flat.iter().copied(), *x_out, nfeatures, 1)
     } else {
         warn!("No clusters created; returning zero matrix");
         let inline_sampling = arrowspacebuilder.sampling.as_ref().unwrap();
@@ -914,7 +911,7 @@ pub(crate) fn run_incremental_clustering_with_sampling(
             inline_sampling
         );
         #[allow(unreachable_code)]
-        DenseMatrix::from_2d_vec(&vec![vec![0.0 as f64; nfeatures]; *x_out]).unwrap()
+        DenseMatrix::from_2d_vec(&vec![vec![0.0_f64; nfeatures]; *x_out]).unwrap()
     };
 
     if arrowspacebuilder.sampling.is_some() {

--- a/src/core.rs
+++ b/src/core.rs
@@ -360,14 +360,17 @@ impl Eq for ScoredItem {}
 
 impl PartialOrd for ScoredItem {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // Reverse for min-heap (smallest score at top)
-        other.score.partial_cmp(&self.score)
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for ScoredItem {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or(Ordering::Equal)
+        // Reverse for min-heap (smallest score at top)
+        other
+            .score
+            .partial_cmp(&self.score)
+            .unwrap_or(Ordering::Equal)
     }
 }
 
@@ -531,16 +534,18 @@ impl ArrowSpace {
         let extra_reduced = proj_data["extra_reduced_dim"].as_bool().unwrap();
         debug!("extra_reduced_dim from proj_data: {}", extra_reduced);
         assert!(
-            extra_reduced == false,
+            !extra_reduced,
             "Reconstructing with extra dim reduction is not implemented yet"
         );
 
         let has_projection = proj_data["pj_mtx_original_dim"].as_usize().is_some();
         debug!("projection present in proj_data: {}", has_projection);
 
-        let mut aspace = Self::default();
-        aspace.nitems = nrows;
-        aspace.nfeatures = ncols;
+        let mut aspace = Self {
+            nitems: nrows,
+            nfeatures: ncols,
+            ..Self::default()
+        };
 
         if has_projection {
             let original_dim = proj_data["pj_mtx_original_dim"]
@@ -639,7 +644,7 @@ impl ArrowSpace {
         let taumode = config
             .get("taumode")
             .and_then(|v| match v {
-                ConfigValue::TauMode(t) => Some(t.clone()),
+                ConfigValue::TauMode(t) => Some(*t),
                 _ => None,
             })
             .unwrap_or_default();
@@ -965,11 +970,9 @@ impl ArrowSpace {
         }
 
         // Eigen mode — validate dimension before computation
-        let valid_dim = if self.projection_matrix.is_some() {
-            let proj = self.projection_matrix.as_ref().unwrap();
-            query.len() == proj.original_dim || query.len() == proj.reduced_dim
-        } else {
-            query.len() == self.nfeatures
+        let valid_dim = match self.projection_matrix.as_ref() {
+            Some(proj) => query.len() == proj.original_dim || query.len() == proj.reduced_dim,
+            None => query.len() == self.nfeatures,
         };
         if !valid_dim {
             return Err(ArrowSpaceError::DimensionMismatch {
@@ -978,9 +981,9 @@ impl ArrowSpace {
             });
         }
 
-        let tau = TauMode::select_tau(&query, self.taumode);
+        let tau = TauMode::select_tau(query, self.taumode);
         let raw_lambda = TauMode::compute_synthetic_lambda(
-            &query,
+            query,
             self.projection_matrix.clone(),
             &gl.matrix,
             tau,
@@ -991,12 +994,12 @@ impl ArrowSpace {
             if relative_eq!(raw_lambda, 0.0, epsilon = 1e-12) {
                 return Err(ArrowSpaceError::DegenerateLambda { raw: raw_lambda });
             }
-            return Ok(self.normalise_query_lambda(raw_lambda));
+            Ok(self.normalise_query_lambda(raw_lambda))
         } else {
             if relative_eq!(raw_lambda, 0.0, epsilon = 1e-12) {
                 return Err(ArrowSpaceError::DegenerateLambda { raw: raw_lambda });
             }
-            return Ok(raw_lambda);
+            Ok(raw_lambda)
         }
     }
 
@@ -1351,14 +1354,14 @@ impl ArrowSpace {
                             index: i,
                             score: lambda_score,
                         });
-                    } else if let Some(&min) = heap.peek() {
-                        if lambda_score > min.score {
-                            heap.pop();
-                            heap.push(ScoredItem {
-                                index: i,
-                                score: lambda_score,
-                            });
-                        }
+                    } else if let Some(&min) = heap.peek()
+                        && lambda_score > min.score
+                    {
+                        heap.pop();
+                        heap.push(ScoredItem {
+                            index: i,
+                            score: lambda_score,
+                        });
                     }
 
                     (heap, sem_best, high_sem)
@@ -1377,11 +1380,11 @@ impl ArrowSpace {
                     for item in h2 {
                         if h1.len() < k {
                             h1.push(item);
-                        } else if let Some(&min) = h1.peek() {
-                            if item.score > min.score {
-                                h1.pop();
-                                h1.push(item);
-                            }
+                        } else if let Some(&min) = h1.peek()
+                            && item.score > min.score
+                        {
+                            h1.pop();
+                            h1.push(item);
                         }
                     }
 
@@ -1597,22 +1600,18 @@ impl ArrowSpace {
         );
 
         // projection matrix
-        if self.projection_matrix.is_some() {
+        if let Some(proj) = self.projection_matrix.as_ref() {
             config.insert(
                 "pj_mtx_original_dim".to_string(),
-                ConfigValue::OptionUsize(Some(
-                    self.projection_matrix.as_ref().unwrap().original_dim,
-                )),
+                ConfigValue::OptionUsize(Some(proj.original_dim)),
             );
             config.insert(
                 "pj_mtx_reduced_dim".to_string(),
-                ConfigValue::OptionUsize(Some(
-                    self.projection_matrix.as_ref().unwrap().reduced_dim,
-                )),
+                ConfigValue::OptionUsize(Some(proj.reduced_dim)),
             );
             config.insert(
                 "pj_mtx_seed".to_string(),
-                ConfigValue::OptionU64(Some(self.projection_matrix.as_ref().unwrap().seed)),
+                ConfigValue::OptionU64(Some(proj.seed)),
             );
 
             config.insert(
@@ -1632,10 +1631,7 @@ impl ArrowSpace {
             config.insert("extra_reduced_dim".to_string(), ConfigValue::Bool(false));
         }
 
-        config.insert(
-            "taumode".to_string(),
-            ConfigValue::TauMode(self.taumode.clone()),
-        );
+        config.insert("taumode".to_string(), ConfigValue::TauMode(self.taumode));
 
         config.insert(
             "n_clusters".to_string(),
@@ -1720,15 +1716,15 @@ impl ArrowSpace {
         let projection_matrix = if let (Some(orig), Some(red), Some(seed)) = (
             config
                 .get("pj_mtx_original_dim")
-                .and_then(|v| Some(v.as_usize()))
+                .map(|v| v.as_usize())
                 .unwrap_or(None),
             config
                 .get("pj_mtx_reduced_dim")
-                .and_then(|v| Some(v.as_usize()))
+                .map(|v| v.as_usize())
                 .unwrap_or(None),
             config
                 .get("pj_mtx_seed")
-                .and_then(|v| Some(v.as_u64()))
+                .map(|v| v.as_u64())
                 .unwrap_or(None),
         ) {
             info!(
@@ -1742,7 +1738,7 @@ impl ArrowSpace {
 
         let reduced_dim = config
             .get("pj_mtx_reduced_dim")
-            .and_then(|v| Some(v.as_usize()))
+            .map(|v| v.as_usize())
             .unwrap_or(None);
 
         // 5. Extract other fields from metadata
@@ -1858,6 +1854,6 @@ impl<'a> IntoIterator for &'a mut ArrowItem {
 pub fn densematrix_to_vecvec(matrix: &DenseMatrix<f64>) -> Vec<Vec<f64>> {
     let (rows, cols) = matrix.shape();
     (0..rows)
-        .map(|r| (0..cols).map(|c| matrix.get((r, c)).clone()).collect())
+        .map(|r| (0..cols).map(|c| *matrix.get((r, c))).collect())
         .collect()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,10 +62,9 @@ impl fmt::Display for ArrowSpaceError {
                  optimal eps. The query item may also be out of context for the \
                  dataset (undecidable)."
             ),
-            Self::NonFiniteQuery => write!(
-                f,
-                "query item contains non-finite values (NaN or Infinity)"
-            ),
+            Self::NonFiniteQuery => {
+                write!(f, "query item contains non-finite values (NaN or Infinity)")
+            }
             Self::DimensionMismatch { expected, got } => write!(
                 f,
                 "dimension mismatch: expected {expected} features, got {got}"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -190,6 +190,9 @@ impl GraphFactory {
     /// This is a lower level method: use `ArrowSpaceBuilder::build`
     /// Transpose the resulting matrix from clustering and build a graph Laplacian matrix
     ///  so to be ready to be used to analyse signal features
+    // Public low-level entry point mirroring the λτ-graph parameter set; the
+    // arguments map 1:1 to `GraphParams` fields plus the raw-data item count.
+    #[allow(clippy::too_many_arguments)]
     pub fn build_laplacian_matrix_from_k_cluster(
         clustered: &DenseMatrix<f64>, // X×F: X centroids of clusters, each with F features
         eps: f64,                     // maximum rectified cosine distance (see `docs/`)
@@ -282,10 +285,9 @@ impl GraphFactory {
             )
         }
 
-        if aspace.reduced_dim.is_some() {
+        if let Some(reduced) = aspace.reduced_dim {
             assert!(
-                aspace.signals.shape().0 == aspace.reduced_dim.unwrap()
-                    && aspace.reduced_dim.unwrap() == aspace.signals.shape().1,
+                aspace.signals.shape().0 == reduced && reduced == aspace.signals.shape().1,
                 "result should be a FxF matrix with reduced dimensions F"
             );
         } else {

--- a/src/maps/eigenmaps.rs
+++ b/src/maps/eigenmaps.rs
@@ -152,7 +152,7 @@ impl EigenMaps for ArrowSpace {
         );
 
         let gl = GraphFactory::build_laplacian_matrix_from_k_cluster(
-            &centroids,
+            centroids,
             builder.lambda_eps,
             builder.lambda_k,
             builder.lambda_topk,

--- a/src/maps/energymaps.rs
+++ b/src/maps/energymaps.rs
@@ -103,11 +103,11 @@ impl EnergyParams {
 
         // Adaptive neighbor_k: scale with graph connectivity
         // Rule: neighbor_k should be 2-3x lambda_k for dense energy graph
-        let neighbor_k = (base_k * 2).max(15).min(50);
+        let neighbor_k = (base_k * 2).clamp(15, 50);
 
         // Adaptive candidate_m: larger pool for better neighbor selection
         // Rule: candidate_m ≈ 2-3x neighbor_k
-        let candidate_m = (neighbor_k * 3).max(30).min(128);
+        let candidate_m = (neighbor_k * 3).clamp(30, 128);
 
         // Adaptive optical compression
         // Priority 1: Use dataset size if available (2√N rule)
@@ -123,7 +123,7 @@ impl EnergyParams {
         } else if builder.use_dims_reduction {
             // Dimensionality-based heuristic (fallback)
             let tokens = (80.0 / dim_reduction_ratio).ceil() as usize;
-            let tokens = tokens.max(40).min(200);
+            let tokens = tokens.clamp(40, 200);
             warn!(
                 "Using dim-reduction heuristic: optical_tokens={} (consider setting expected_nitems for better scaling)",
                 tokens
@@ -175,7 +175,7 @@ impl EnergyParams {
     pub fn compute_adaptive_tokens(nitems: usize) -> usize {
         let sqrt_n = (nitems as f64).sqrt();
         let tokens = (sqrt_n * 2.0).round() as usize;
-        tokens.max(100).min(2000)
+        tokens.clamp(100, 2000)
     }
 
     /// Creates EnergyParams with minimal compression for maximum resolution.
@@ -211,8 +211,8 @@ impl EnergyParams {
 
         Self {
             optical_tokens: Some(100), // Aggressive compression
-            neighbor_k: builder.lambda_k.max(15).min(30),
-            candidate_m: (builder.lambda_k * 2).max(30).min(80),
+            neighbor_k: builder.lambda_k.clamp(15, 30),
+            candidate_m: (builder.lambda_k * 2).clamp(30, 80),
 
             // Fewer diffusion steps for speed
             steps: 3,
@@ -762,7 +762,7 @@ impl EnergyMaps for ArrowSpace {
 // ------- helpers with logging -------
 
 /// Compute 2D bounding box for projected points.
-fn minmax2d(xy: &Vec<f64>) -> (f64, f64, f64, f64) {
+fn minmax2d(xy: &[f64]) -> (f64, f64, f64, f64) {
     trace!("Computing 2D bounds over {} points", xy.len() / 2);
     let mut minx = f64::INFINITY;
     let mut maxx = f64::NEG_INFINITY;
@@ -780,7 +780,7 @@ fn minmax2d(xy: &Vec<f64>) -> (f64, f64, f64, f64) {
 }
 
 /// Remove high-norm items from a set using quantile-based trimming.
-fn trim_high_norm(dm: &DenseMatrix<f64>, idx: &Vec<usize>, q: f64) -> Vec<usize> {
+fn trim_high_norm(dm: &DenseMatrix<f64>, idx: &[usize], q: f64) -> Vec<usize> {
     trace!(
         "Trimming high-norm items: {} candidates, quantile={:.2} [parallel]",
         idx.len(),
@@ -817,7 +817,7 @@ fn trim_high_norm(dm: &DenseMatrix<f64>, idx: &Vec<usize>, q: f64) -> Vec<usize>
 }
 
 /// Compute element-wise mean of selected matrix rows.
-fn mean_rows(dm: &DenseMatrix<f64>, idx: &Vec<usize>) -> Vec<f64> {
+fn mean_rows(dm: &DenseMatrix<f64>, idx: &[usize]) -> Vec<f64> {
     let f = dm.shape().1;
     if idx.is_empty() {
         trace!("mean_rows: empty index, returning zero vector");
@@ -826,12 +826,12 @@ fn mean_rows(dm: &DenseMatrix<f64>, idx: &Vec<usize>) -> Vec<f64> {
     trace!("Computing mean of {} rows", idx.len());
     let mut acc = vec![0.0; f];
     for &i in idx {
-        for c in 0..f {
-            acc[c] += *dm.get((i, c));
+        for (c, a) in acc.iter_mut().enumerate() {
+            *a += *dm.get((i, c));
         }
     }
-    for c in 0..f {
-        acc[c] /= idx.len() as f64;
+    for a in &mut acc {
+        *a /= idx.len() as f64;
     }
     acc
 }
@@ -842,7 +842,7 @@ fn mean_rows(dm: &DenseMatrix<f64>, idx: &Vec<usize>) -> Vec<f64> {
 // }
 
 /// Compute unit direction vector from a to b.
-fn unit_diff(a: Vec<f64>, b: &Vec<f64>) -> Vec<f64> {
+fn unit_diff(a: Vec<f64>, b: &[f64]) -> Vec<f64> {
     let mut d: Vec<f64> = a.iter().zip(b.iter()).map(|(x, y)| x - y).collect();
     let n = (d.iter().map(|v| v * v).sum::<f64>()).sqrt().max(1e-9);
     for v in d.iter_mut() {
@@ -852,7 +852,7 @@ fn unit_diff(a: Vec<f64>, b: &Vec<f64>) -> Vec<f64> {
 }
 
 /// Compute local standard deviation between two vectors.
-fn local_std(a: Vec<f64>, b: &Vec<f64>) -> f64 {
+fn local_std(a: Vec<f64>, b: &[f64]) -> f64 {
     let diffs: Vec<f64> = a.iter().zip(b.iter()).map(|(x, y)| x - y).collect();
     let mean = diffs.iter().sum::<f64>() / diffs.len().max(1) as f64;
     let var =
@@ -861,13 +861,13 @@ fn local_std(a: Vec<f64>, b: &Vec<f64>) -> f64 {
 }
 
 /// Add a scaled direction vector to a base vector.
-fn add_scaled(a: &Vec<f64>, dir: &Vec<f64>, t: f64) -> Vec<f64> {
+fn add_scaled(a: &[f64], dir: &[f64], t: f64) -> Vec<f64> {
     a.iter().zip(dir.iter()).map(|(x, d)| x + t * d).collect()
 }
 
 /// Compute element-wise difference between two vectors.
 #[allow(dead_code)]
-fn vec_diff(a: &Vec<f64>, b: &Vec<f64>) -> Vec<f64> {
+fn vec_diff(a: &[f64], b: &[f64]) -> Vec<f64> {
     a.iter().zip(b.iter()).map(|(x, y)| x - y).collect()
 }
 
@@ -892,16 +892,16 @@ fn topk_by_l2(dm: &DenseMatrix<f64>, i: usize, k: usize) -> Vec<usize> {
 }
 
 /// Compute robust scale estimate using Median Absolute Deviation (MAD).
-fn robust_scale(x: &Vec<f64>) -> f64 {
+fn robust_scale(x: &[f64]) -> f64 {
     if x.is_empty() {
         trace!("robust_scale: empty vector, returning 1.0");
         return 1.0;
     }
-    let mut v = x.clone();
+    let mut v = x.to_vec();
     v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
     let median = v[v.len() / 2];
     let mut devs: Vec<f64> = v.iter().map(|t| (t - median).abs()).collect();
-    devs.sort_by(|a, b| a.partial_cmp(&b).unwrap_or(Ordering::Equal));
+    devs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
     let mad = devs[devs.len() / 2];
     let scale = (1.4826 * mad).max(1e-9);
     trace!(
@@ -1119,10 +1119,10 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
         energy_params: EnergyParams,
     ) -> (ArrowSpace, GraphLaplacian) {
         assert!(
-            self.use_dims_reduction == true,
+            self.use_dims_reduction,
             "When using build_energy, dim reduction is needed"
         );
-        if self.prebuilt_spectral == true {
+        if self.prebuilt_spectral {
             panic!(
                 "Spectral mode not compatible with build_energy, please do not enable for energy search"
             );
@@ -1165,7 +1165,7 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
         }
 
         // Step 3: Bootstrap Laplacian on centroids
-        let l0: GraphLaplacian = ArrowSpace::bootstrap_centroid_laplacian(&centroids, &self);
+        let l0: GraphLaplacian = ArrowSpace::bootstrap_centroid_laplacian(&centroids, self);
 
         assert_eq!(centroids.shape().0, l0.nnodes, "l0 is still non-projected");
 
@@ -1196,7 +1196,7 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
             ArrowSpace::subcentroids_from_dense_matrix(sub_centroids.clone());
         subcentroid_space.taumode = aspace.taumode;
         subcentroid_space.projection_matrix = aspace.projection_matrix.clone();
-        subcentroid_space.reduced_dim = aspace.reduced_dim.clone();
+        subcentroid_space.reduced_dim = aspace.reduced_dim;
         // safeguard to clear signals
         subcentroid_space.signals = sprs::CsMat::empty(sprs::CSR, 0);
 
@@ -1407,7 +1407,7 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
         );
 
         trace!("Bootstrapping F×F Laplacian for taumode computation");
-        let l_boot = ArrowSpace::bootstrap_centroid_laplacian(sub_centroids, &self);
+        let l_boot = ArrowSpace::bootstrap_centroid_laplacian(sub_centroids, self);
 
         assert_eq!(
             l_boot.matrix.rows(),

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -54,7 +54,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::{info, trace};
-use rand::{rngs::StdRng, rngs::SysRng, RngExt, SeedableRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng, rngs::SysRng};
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -214,11 +214,7 @@ impl InlineSampler for DensityAdaptiveSampler {
 
         trace!(
             "Row {}: dist²={:.4}, sat={:.2}, rate={:.4}, keep={}",
-            self.current_idx,
-            nearest_dist_sq,
-            saturation,
-            adaptive_rate,
-            keep
+            self.current_idx, nearest_dist_sq, saturation, adaptive_rate, keep
         );
 
         keep

--- a/src/search/taumode.rs
+++ b/src/search/taumode.rs
@@ -274,26 +274,23 @@ impl TauMode {
         }
 
         // project only if unprojected
-        let projected_item = if projection_matrix.is_some()
-            && item_vector.len() == projection_matrix.as_ref().unwrap().original_dim
-        {
-            projection_matrix.unwrap().project(&item_vector)
-        } else if projection_matrix.is_none()
-            || item_vector.len() == projection_matrix.as_ref().unwrap().reduced_dim
-        {
-            item_vector.to_owned()
-        } else {
-            panic!(
-                "Check the projection pipeline, item seems neither projected nor unprojected. \n\
-                   input item len: {:?} \
-                   projection matrix is set: {} \
-                   projection matrix original dims: {} \
-                   projection matrix reduced dims: {}",
-                item_vector.len(),
-                projection_matrix.as_ref().is_some(),
-                projection_matrix.as_ref().unwrap().original_dim,
-                projection_matrix.as_ref().unwrap().reduced_dim
-            )
+        let projected_item = match projection_matrix {
+            Some(proj) if item_vector.len() == proj.original_dim => proj.project(item_vector),
+            Some(proj) if item_vector.len() == proj.reduced_dim => item_vector.to_owned(),
+            None => item_vector.to_owned(),
+            Some(proj) => {
+                panic!(
+                    "Check the projection pipeline, item seems neither projected nor unprojected. \n\
+                       input item len: {:?} \
+                       projection matrix is set: {} \
+                       projection matrix original dims: {} \
+                       projection matrix reduced dims: {}",
+                    item_vector.len(),
+                    true,
+                    proj.original_dim,
+                    proj.reduced_dim
+                )
+            }
         };
 
         // Parallel computation of E_raw and G_raw

--- a/src/storage/parquet.rs
+++ b/src/storage/parquet.rs
@@ -589,6 +589,9 @@ pub fn load_sparse_matrix(path: impl AsRef<Path>) -> Result<CsMat<f64>, StorageE
 /// Save all ArrowSpace artifacts using ArrowSpaceBuilder directly
 ///
 /// This is the recommended approach - pass the builder directly.
+// Each argument is a distinct persisted artifact of the checkpoint; grouping
+// them into a struct would only relocate the same list without adding meaning.
+#[allow(clippy::too_many_arguments)]
 pub fn save_arrowspace_checkpoint_with_builder(
     path: impl AsRef<Path>,
     checkpoint_name: &str,
@@ -845,11 +848,10 @@ pub fn load_lambda(path: impl AsRef<Path>) -> Result<Vec<f64>, StorageError> {
             if let Some(n_values_col) = batch
                 .column_by_name("n_values")
                 .and_then(|c| c.as_any().downcast_ref::<UInt64Array>())
+                && !n_values_col.is_empty()
             {
-                if !n_values_col.is_empty() {
-                    let n_values = n_values_col.value(0) as usize;
-                    lambdas.reserve(n_values);
-                }
+                let n_values = n_values_col.value(0) as usize;
+                lambdas.reserve(n_values);
             }
         }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod test_laplacian_unnormalised;
 mod test_motives;
 mod test_querying_proj;
 mod test_reduction;
+mod test_sequencing;
 mod test_taumode;
 
 use std::sync::Once;

--- a/src/tests/test_error.rs
+++ b/src/tests/test_error.rs
@@ -100,10 +100,7 @@ fn test_try_prepare_query_item_dimension_mismatch_returns_err() {
 
     let result = aspace.try_prepare_query_item(&wrong_query, &gl);
     match result {
-        Err(ArrowSpaceError::DimensionMismatch {
-            expected,
-            got,
-        }) => {
+        Err(ArrowSpaceError::DimensionMismatch { expected, got }) => {
             assert_eq!(expected, aspace.nfeatures);
             assert_eq!(got, aspace.nfeatures / 2);
         }
@@ -233,7 +230,12 @@ fn test_try_search_lambda_aware_matches_search_lambda_aware() {
     assert_eq!(fallible.len(), infallible.len());
     for (a, b) in fallible.iter().zip(infallible.iter()) {
         assert_eq!(a.0, b.0, "index mismatch");
-        assert!((a.1 - b.1).abs() < 1e-12, "score mismatch: {} vs {}", a.1, b.1);
+        assert!(
+            (a.1 - b.1).abs() < 1e-12,
+            "score mismatch: {} vs {}",
+            a.1,
+            b.1
+        );
     }
 }
 

--- a/src/tests/test_sequencing.rs
+++ b/src/tests/test_sequencing.rs
@@ -1,0 +1,218 @@
+use smartcore::linalg::basic::arrays::Array2;
+use smartcore::linalg::basic::matrix::DenseMatrix;
+use sprs::TriMat;
+
+use crate::analysis::sequencing::{sequence_by_graph, sequence_by_lambda};
+use crate::graph::{GraphLaplacian, GraphParams};
+use crate::laplacian::build_laplacian_matrix;
+
+/// Build a GraphLaplacian directly from Laplacian triplets (i, j, value).
+/// Sequencing operates on `matrix` alone, so `init_data` stays empty.
+fn laplacian_from_triplets(n: usize, triplets: &[(usize, usize, f64)]) -> GraphLaplacian {
+    let mut tm = TriMat::new((n, n));
+    for &(i, j, v) in triplets {
+        tm.add_triplet(i, j, v);
+    }
+    GraphLaplacian {
+        init_data: DenseMatrix::new(0, 0, vec![], true).unwrap(),
+        matrix: tm.to_csr(),
+        nnodes: n,
+        graph_params: GraphParams {
+            eps: 0.9,
+            k: 4,
+            topk: 4,
+            p: 2.0,
+            sigma: None,
+            normalise: false,
+            sparsity_check: false,
+        },
+        energy: false,
+    }
+}
+
+/// Path-graph Laplacian for nodes 0-1-2-3-4 with unit edge weights.
+fn path_laplacian(n: usize) -> GraphLaplacian {
+    let mut triplets: Vec<(usize, usize, f64)> = Vec::new();
+    for i in 0..n {
+        let degree = if i == 0 || i == n - 1 { 1.0 } else { 2.0 };
+        triplets.push((i, i, degree));
+        if i > 0 {
+            triplets.push((i, i - 1, -1.0));
+            triplets.push((i - 1, i, -1.0));
+        }
+    }
+    laplacian_from_triplets(n, &triplets)
+}
+
+#[test]
+fn test_sequence_by_lambda_orders_ascending_and_descending() {
+    let lambdas = [0.5, 0.1, 0.9];
+
+    let asc = sequence_by_lambda(&lambdas, false);
+    assert_eq!(asc.order, vec![1, 0, 2]);
+    assert_eq!(asc.positions, vec![0.1, 0.5, 0.9]);
+    assert_eq!(asc.components, 1);
+
+    let desc = sequence_by_lambda(&lambdas, true);
+    assert_eq!(desc.order, vec![2, 0, 1]);
+    assert_eq!(desc.positions, vec![0.9, 0.5, 0.1]);
+}
+
+#[test]
+fn test_sequence_by_lambda_is_permutation_and_deterministic() {
+    let lambdas = [0.7, 0.3, 0.9, 0.1];
+    let a = sequence_by_lambda(&lambdas, false);
+    let b = sequence_by_lambda(&lambdas, false);
+
+    assert_eq!(a.order, b.order);
+    assert_eq!(a.positions, b.positions);
+
+    let mut sorted = a.order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, vec![0, 1, 2, 3]);
+}
+
+#[test]
+fn test_sequence_by_graph_walks_path_monotonically() {
+    let gl = path_laplacian(5);
+    let seq = sequence_by_graph(&gl);
+
+    // A path graph has one connected component...
+    assert_eq!(seq.components, 1);
+    // ...and seriation must recover the chain exactly.
+    assert_eq!(seq.order, vec![0, 1, 2, 3, 4]);
+
+    for step in seq.order.windows(2) {
+        let d = step[1] as isize - step[0] as isize;
+        assert!(
+            d.abs() == 1,
+            "consecutive steps must be graph neighbours, got {step:?}"
+        );
+    }
+    // Positions are discovery depths along the walk.
+    assert_eq!(seq.positions, vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn test_sequence_by_graph_is_deterministic_and_reversible_on_path() {
+    let gl = path_laplacian(6);
+    let a = sequence_by_graph(&gl);
+    let b = sequence_by_graph(&gl);
+
+    assert_eq!(a.order, b.order);
+    assert_eq!(a.positions, b.positions);
+
+    // The reverse chain is an equally valid seriation; either direction must
+    // be a monotone walk over the path.
+    for w in a.order.windows(2) {
+        let d = w[1] as isize - w[0] as isize;
+        assert_eq!(d.abs(), 1);
+    }
+}
+
+#[test]
+fn test_sequence_by_graph_keeps_disjoint_cliques_contiguous() {
+    // Complete triangle {0,1,2} (weight 1) disjoint from pair {3,4}.
+    let triplets = [
+        (0, 0, 2.0),
+        (0, 1, -1.0),
+        (1, 0, -1.0),
+        (1, 1, 2.0),
+        (0, 2, -1.0),
+        (2, 0, -1.0),
+        (1, 2, -1.0),
+        (2, 1, -1.0),
+        (2, 2, 2.0),
+        (3, 3, 1.0),
+        (3, 4, -1.0),
+        (4, 3, -1.0),
+        (4, 4, 1.0),
+    ];
+    let gl = laplacian_from_triplets(5, &triplets);
+    let seq = sequence_by_graph(&gl);
+
+    assert_eq!(seq.components, 2);
+
+    // Larger component first; blocks are contiguous.
+    let head: std::collections::HashSet<usize> = seq.order[..3].iter().copied().collect();
+    let tail: std::collections::HashSet<usize> = seq.order[3..].iter().copied().collect();
+    assert_eq!(head, [0, 1, 2].into_iter().collect());
+    assert_eq!(tail, [3, 4].into_iter().collect());
+
+    // No interleaving across components anywhere in the order.
+    let mut seen_pair = false;
+    for &n in &seq.order {
+        if n >= 3 {
+            seen_pair = true;
+        } else {
+            assert!(!seen_pair, "components must not interleave");
+        }
+    }
+}
+
+#[test]
+fn test_sequence_by_graph_edgeless_laplacian_yields_identity_order() {
+    let gl = laplacian_from_triplets(3, &[(0, 0, 0.0), (1, 1, 0.0), (2, 2, 0.0)]);
+    let seq = sequence_by_graph(&gl);
+
+    assert_eq!(seq.components, 3);
+    assert_eq!(seq.order, vec![0, 1, 2]);
+    assert!(seq.positions.iter().all(|&p| p == 0.0));
+}
+
+#[test]
+fn test_sequence_by_graph_handles_isolated_nodes_attached_to_component() {
+    // Clique {0,1} plus isolated nodes 2 and 3.
+    let triplets = [
+        (0, 0, 1.0),
+        (0, 1, -1.0),
+        (1, 0, -1.0),
+        (1, 1, 1.0),
+        (2, 2, 0.0),
+        (3, 3, 0.0),
+    ];
+    let gl = laplacian_from_triplets(4, &triplets);
+    let seq = sequence_by_graph(&gl);
+
+    assert_eq!(seq.components, 3);
+    // Connected component (size 2) precedes singletons.
+    assert_eq!(seq.order[..2], [0, 1]);
+}
+
+#[test]
+fn test_sequence_by_graph_on_pipeline_laplacian_is_permutation() {
+    let items = vec![
+        vec![1.0, 0.0, 0.0],
+        vec![0.8, 0.6, 0.0],
+        vec![0.9, 0.1, 0.0],
+        vec![0.0, 1.0, 0.0],
+        vec![0.0, 0.8, 0.6],
+        vec![0.0, 0.0, 1.0],
+    ];
+    let params = GraphParams {
+        eps: 0.5,
+        k: 3,
+        topk: 2,
+        p: 2.0,
+        sigma: Some(0.1),
+        normalise: false,
+        sparsity_check: true,
+    };
+    let gl = build_laplacian_matrix(
+        DenseMatrix::<f64>::from_2d_vec(&items).unwrap().transpose(),
+        &params,
+        None,
+        false,
+    );
+
+    let seq = sequence_by_graph(&gl);
+
+    // Valid permutation of the Laplacian nodes, deterministic across calls.
+    let mut sorted = seq.order.clone();
+    sorted.sort_unstable();
+    assert_eq!(sorted, (0..seq.order.len()).collect::<Vec<_>>());
+
+    let again = sequence_by_graph(&gl);
+    assert_eq!(seq.order, again.order);
+    assert_eq!(seq.positions, again.positions);
+}


### PR DESCRIPTION
Fixes #133

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied

### Current behaviour
No sequencing capability existed: there was no way to extract a total ordering (seriation) of the Laplacian nodes. The Fiedler-vector approach sketched for this issue was rejected because it violates the crate's invariants (`AGENTS.md`): arrowspace computes in discrete spaces only — no eigensolvers, no continuous embeddings.

### New expected behaviour
New module `analysis::sequencing` providing two discrete strategies over `GraphLaplacian.matrix`:

- **`sequence_by_lambda(lambdas, descending)`** — total order by per-node λ score (Rayleigh read-out); a spectral curriculum from low to high energy. Deterministic index tie-breaking.
- **`sequence_by_graph(gl)`** — MST-chain seriation:
  1. adjacency recovered exactly from L = D − A (no similarity recomputation)
  2. minimum spanning forest via Prim's algorithm, heap ties resolved by `(weight, node, parent)`
  3. each tree rooted at an approximate diameter endpoint found by double-sweep BFS
  4. DFS preorder walk, smaller-index children first
  5. components emitted as contiguous blocks ordered by (size desc, min index asc)

Returns `Sequence { order, positions, components }`: `order` is a permutation of the matrix nodes, `positions` reports per-step λ or DFS discovery depth.

Complexity O(E log V + V), flat memory (sorted arrays + binary heap), fully deterministic. This is the discrete counterpart of Fiedler-vector seriation — approximates a minimum linear arrangement without computing any vector.

### Verification
- TDD: 8 new tests written first (RED) against synthetic Laplacians (path graphs, disjoint cliques, edgeless, isolated nodes) plus a pipeline-built Laplacian; they caught two real bugs during GREEN (unreachable-node distance scan marking other components as farthest; shared visited state starving the DFS)
- 266 lib tests pass (`--release`), doctests pass, rustfmt clean
- clippy `-Drust-2018-idioms -Dwarnings --all-features`: **exit 0, zero errors** (the 78 pre-existing lints on main are resolved in this PR)

### Change logs

#### Added
- `analysis::sequencing::{Sequence, sequence_by_lambda, sequence_by_graph}` — eigensolver-free node sequencing over the graph Laplacian

#### Changed
- Version bump 0.26.10 → 0.26.11
