### PR TITLE
fix(core): restore persisted lambda stats in from_config (#158)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/core.rs
+++ b/src/core.rs
@@ -664,6 +664,35 @@ impl ArrowSpace {
             n_clusters, cluster_radius
         );
 
+        // --- Lambda statistics ---
+        let lambda_stat = |key: &str| match config.get(key) {
+            Some(ConfigValue::F64(v)) => Some(*v),
+            Some(ConfigValue::OptionF64(v)) => *v,
+            _ => None,
+        };
+        let (min_lambdas, max_lambdas, range_lambdas) = match (
+            lambda_stat("min_lambdas"),
+            lambda_stat("max_lambdas"),
+            lambda_stat("range_lambdas"),
+        ) {
+            (Some(min), Some(max), Some(range))
+                if min.is_finite()
+                    && max.is_finite()
+                    && range.is_finite()
+                    && range > 0.0
+                    && min <= max =>
+            {
+                (min, max, range)
+            }
+            _ => {
+                warn!(
+                    "ArrowSpace::from_config: lambda statistics missing or inconsistent, \
+                     restoring as un-normalised space"
+                );
+                (-1.0, -1.0, -1.0)
+            }
+        };
+
         // --- Empty data and auxiliary fields ---
         let data = DenseMatrix::new(0, 0, Vec::new(), true).unwrap();
         let signals = sprs::CsMat::zero((0, 0));
@@ -678,9 +707,9 @@ impl ArrowSpace {
             lambdas,
             lambdas_sorted,
             // Normalization fields
-            min_lambdas: -1.0,
-            max_lambdas: -1.0,
-            range_lambdas: -1.0,
+            min_lambdas,
+            max_lambdas,
+            range_lambdas,
             taumode,
             n_clusters,
             cluster_assignments: Vec::new(),
@@ -1655,19 +1684,6 @@ impl ArrowSpace {
         config.insert(
             "cluster_radius".to_string(),
             ConfigValue::F64(self.cluster_radius),
-        );
-
-        config.insert(
-            "min_lambdas".to_string(),
-            ConfigValue::F64(self.min_lambdas),
-        );
-        config.insert(
-            "max_lambdas".to_string(),
-            ConfigValue::F64(self.max_lambdas),
-        );
-        config.insert(
-            "range_lambdas".to_string(),
-            ConfigValue::F64(self.range_lambdas),
         );
 
         config

--- a/src/storage/tests/test_parquet.rs
+++ b/src/storage/tests/test_parquet.rs
@@ -30,7 +30,7 @@ fn create_forced_multibatch_parquet(
 ) {
     let file = File::create(path).unwrap();
     let props = WriterProperties::builder()
-        .set_max_row_group_size(1024)
+        .set_max_row_group_row_count(Some(1024))
         .build();
 
     let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();

--- a/src/tests/test_arrow.rs
+++ b/src/tests/test_arrow.rs
@@ -593,3 +593,129 @@ fn test_arrowspace_config_typed_with_projection() {
     assert!(config.get("n_clusters").is_some());
     assert!(config.get("cluster_radius").is_some());
 }
+
+#[test]
+fn test_from_config_restores_lambda_stats() {
+    // Build an ArrowSpace so lambdas are computed and normalised
+    let items = make_gaussian_blob(99, 0.5);
+    let (aspace, gl) = ArrowSpaceBuilder::default()
+        .with_lambda_graph(0.3, 3, 2, 2.0, None)
+        .with_seed(42)
+        .build(items.clone());
+
+    // Lambda stats must be real (not the -1.0 sentinel) after a normal build
+    assert!(
+        aspace.range_lambdas > 0.0,
+        "built ArrowSpace must have positive range_lambdas, got {}",
+        aspace.range_lambdas
+    );
+
+    // Persist and restore
+    let config = aspace.arrowspace_config_typed();
+    let restored = ArrowSpace::from_config(config);
+
+    // The restored space must carry the original lambda stats
+    assert!(
+        restored.min_lambdas.is_finite(),
+        "from_config must restore min_lambdas, got {}",
+        restored.min_lambdas
+    );
+    assert!(
+        restored.max_lambdas.is_finite(),
+        "from_config must restore max_lambdas, got {}",
+        restored.max_lambdas
+    );
+    assert!(
+        restored.range_lambdas > 0.0,
+        "from_config must restore positive range_lambdas, got {}",
+        restored.range_lambdas
+    );
+    assert!(
+        (restored.min_lambdas - aspace.min_lambdas).abs() < 1e-12,
+        "restored min_lambdas {} != original {}",
+        restored.min_lambdas,
+        aspace.min_lambdas
+    );
+    assert!(
+        (restored.max_lambdas - aspace.max_lambdas).abs() < 1e-12,
+        "restored max_lambdas {} != original {}",
+        restored.max_lambdas,
+        aspace.max_lambdas
+    );
+    assert!(
+        (restored.range_lambdas - aspace.range_lambdas).abs() < 1e-12,
+        "restored range_lambdas {} != original {}",
+        restored.range_lambdas,
+        aspace.range_lambdas
+    );
+
+    // Query-level round-trip: the restored space must prepare query lambdas
+    // exactly like the original (issue #158: restored spaces normalised every
+    // query lambda to 0.0, tripping DegenerateLambda on every search)
+    let query = items[0].clone();
+    let lambda_original = aspace
+        .try_prepare_query_item(&query, &gl)
+        .expect("original space must prepare the query");
+    let lambda_restored = restored
+        .try_prepare_query_item(&query, &gl)
+        .expect("restored space must prepare the query");
+    assert!(
+        lambda_restored.abs() > 1e-12,
+        "restored space must not normalise query lambda to 0.0, got {}",
+        lambda_restored
+    );
+    assert!(
+        (lambda_original - lambda_restored).abs() < 1e-9,
+        "restored query lambda {} != original {}",
+        lambda_restored,
+        lambda_original
+    );
+}
+
+#[test]
+fn test_from_config_without_lambda_stats_keeps_sentinel() {
+    // A config missing the lambda-stats keys restores as un-normalised
+    let mut config = HashMap::new();
+    config.insert("nitems".to_string(), ConfigValue::Usize(3));
+    config.insert("nfeatures".to_string(), ConfigValue::Usize(4));
+
+    let restored = ArrowSpace::from_config(config);
+
+    assert_eq!(restored.min_lambdas, -1.0);
+    assert_eq!(restored.max_lambdas, -1.0);
+    assert_eq!(restored.range_lambdas, -1.0);
+}
+
+#[test]
+fn test_from_config_with_nonpositive_range_keeps_sentinel() {
+    // range_lambdas <= 0 is internally inconsistent: reject the whole triple
+    let mut config = HashMap::new();
+    config.insert("nitems".to_string(), ConfigValue::Usize(3));
+    config.insert("nfeatures".to_string(), ConfigValue::Usize(4));
+    config.insert("min_lambdas".to_string(), ConfigValue::F64(2.0));
+    config.insert("max_lambdas".to_string(), ConfigValue::F64(5.0));
+    config.insert("range_lambdas".to_string(), ConfigValue::F64(-1.0));
+
+    let restored = ArrowSpace::from_config(config);
+
+    assert_eq!(restored.min_lambdas, -1.0);
+    assert_eq!(restored.max_lambdas, -1.0);
+    assert_eq!(restored.range_lambdas, -1.0);
+}
+
+#[test]
+fn test_from_config_with_inverted_min_max_keeps_sentinel() {
+    // min_lambdas > max_lambdas is internally inconsistent: reject the triple
+    let mut config = HashMap::new();
+    config.insert("nitems".to_string(), ConfigValue::Usize(3));
+    config.insert("nfeatures".to_string(), ConfigValue::Usize(4));
+    config.insert("min_lambdas".to_string(), ConfigValue::F64(5.0));
+    config.insert("max_lambdas".to_string(), ConfigValue::F64(2.0));
+    config.insert("range_lambdas".to_string(), ConfigValue::F64(3.0));
+
+    let restored = ArrowSpace::from_config(config);
+
+    assert_eq!(restored.min_lambdas, -1.0);
+    assert_eq!(restored.max_lambdas, -1.0);
+    assert_eq!(restored.range_lambdas, -1.0);
+}


### PR DESCRIPTION
## Summary

`ArrowSpace::from_config` hardcoded `min_lambdas`/`max_lambdas`/`range_lambdas` to the `-1.0` sentinel and never read the persisted stats keys, so every restored ArrowSpace normalised query lambdas with bogus stats and soft-failed every search (`DegenerateLambda`: `(raw - (-1)) / -1` clamps to `0.0`).

Closes #158.

## Changes

- `from_config` now reads the three lambda-stats keys from the `ConfigValue` map (variant-matched, no panics on foreign configs). Stats are used when finite, `range_lambdas > 0.0` and `min <= max`; otherwise the `-1.0` sentinel is kept and a warning is surfaced.
- Not following the issue's `normalise_lambdas()` fallback: `from_config` holds all-zero lambdas, so re-normalising would fabricate `range = 1e-9`. The sentinel is the correct un-normalised state.
- Removed the duplicate stats insertion in `arrowspace_config_typed()` (same keys emitted twice, second silently overwrote the first).
- Patch version bump to `0.27.1`.

## Tests (TDD)

- Reproduction test written first and confirmed failing (`restored range_lambdas == -1`).
- `test_from_config_restores_lambda_stats`: config round-trip restores exact stats **and** query-level parity — restored `try_prepare_query_item` returns a non-zero lambda matching the original space (the issue's actual symptom).
- Fallback contract: missing keys, non-positive range, inverted min/max → sentinel preserved.

## Verification

- `cargo test --release`: 283 passed, 0 failed.
- `cargo clippy`: warning count unchanged (96 before/after).
- `cargo fmt --check`: no new diffs.
- No public signature, enum variant or panic-behaviour changes; pyarrowspace FFI surface unaffected (restore path gains stats it previously discarded).