### PR TITLE
chore: bump to 0.27.2, replace yanked chacha20 0.10.1 lockfile entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "approx 0.5.1",
  "arrow",
@@ -486,9 +486,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.27.1"
+version = "0.27.2"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]


### PR DESCRIPTION
## Summary

- Refreshes the `chacha20 v0.10.1` entry in `Cargo.lock` (transitive via `rand 0.10.2`) to `v0.10.2`, which is not yanked on crates-io. Clears the `package `chacha20 v0.10.1` ... is yanked` warning on every cargo invocation.
- Patch version bump to `0.27.2`.

No code changes; `chacha20` is only reachable through `rand`'s seeded RNG backend, and the patch bump is API-identical.

## Verification

- `cargo check`: no yank warning.
- `cargo tree -i chacha20`: single entry at `0.10.2` via `rand 0.10.2`.