### PR TITLE
fix(analysis): enforce energy-mode requirements in motif spotting (#161)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.27.2"
+version = "0.27.3"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/analysis/motives.rs
+++ b/src/analysis/motives.rs
@@ -117,9 +117,28 @@ pub trait Motives {
     /// 2) Map each subcentroid-set to original item indices via ArrowSpace.centroid_map.
     /// 3) Deduplicate and return item-index motifs.
     ///
-    /// Requirements:
+    /// Requirements (enforced — the method returns
+    /// [`ArrowSpaceError::EnergyModeRequired`](crate::error::ArrowSpaceError::EnergyModeRequired)
+    /// instead of degrading):
     /// - self.energy must be true (built via build_energy)
+    /// - aspace.sub_centroids must be Some, so motif detection runs in
+    ///   subcentroid space rather than over the F×F bootstrap Laplacian
+    ///   (whose nodes enumerate features)
     /// - aspace.centroid_map must be Some(Vec<usize>) mapping item -> subcentroid index
+    ///
+    /// Use this fallible variant; the panicking twin
+    /// [`Motives::spot_motives_energy`] is deprecated since 0.27.3.
+    fn try_spot_motives_energy(
+        &self,
+        aspace: &crate::core::ArrowSpace,
+        cfg: &crate::analysis::motives::MotiveConfig,
+    ) -> Result<Vec<Vec<usize>>, crate::error::ArrowSpaceError>;
+
+    /// Panicking twin of [`Motives::try_spot_motives_energy`].
+    #[deprecated(
+        since = "0.27.3",
+        note = "use try_spot_motives_energy; this panics on non-energy builds"
+    )]
     fn spot_motives_energy(
         &self,
         aspace: &crate::core::ArrowSpace,
@@ -296,15 +315,39 @@ impl Motives for GraphLaplacian {
         out
     }
 
-    fn spot_motives_energy(
+    fn try_spot_motives_energy(
         &self,
         aspace: &crate::core::ArrowSpace,
         cfg: &MotiveConfig,
-    ) -> Vec<Vec<usize>> {
+    ) -> Result<Vec<Vec<usize>>, crate::error::ArrowSpaceError> {
+        use crate::error::ArrowSpaceError;
+
+        // Enforce the documented requirements (issue #161). Degrading silently
+        // here ran motif detection over the F×F bootstrap Laplacian — whose
+        // nodes enumerate FEATURES — and returned the ids as item indices.
+        if !self.energy {
+            return Err(ArrowSpaceError::EnergyModeRequired {
+                missing: "energy build (use EnergyMapsBuilder::build_energy)",
+            });
+        }
+        if aspace.sub_centroids.is_none() {
+            return Err(ArrowSpaceError::EnergyModeRequired {
+                missing: "sub_centroids on the ArrowSpace index",
+            });
+        }
+        let cmap = match &aspace.centroid_map {
+            Some(m) => m,
+            None => {
+                return Err(ArrowSpaceError::EnergyModeRequired {
+                    missing: "centroid_map on the ArrowSpace index",
+                });
+            }
+        };
+
         // Operate strictly on the energy Laplacian over subcentroids
         let (rows, cols) = self.matrix.shape();
         if rows == 0 || rows != cols {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let n_sc = rows;
 
@@ -510,24 +553,8 @@ impl Motives for GraphLaplacian {
             sc_results.len()
         );
 
-        // 6) Map to item indices via centroid_map (parallel)
-        let cmap = match &aspace.centroid_map {
-            Some(m) => m,
-            None => {
-                // Return subcentroid motifs if mapping not available
-                let mut out_sc: Vec<Vec<usize>> = sc_results
-                    .into_iter()
-                    .map(|res| {
-                        let mut v: Vec<usize> = res.into_iter().collect();
-                        v.sort_unstable();
-                        v
-                    })
-                    .collect();
-                out_sc.shrink_to_fit();
-                return out_sc;
-            }
-        };
-
+        // 6) Map to item indices via centroid_map (parallel) — the map is
+        // guaranteed present by the requirement checks above.
         // sc_id -> items (parallel build with local buckets, then merge)
         cmap.par_iter().enumerate().for_each(|(_, &sc_idx)| {
             if sc_idx < n_sc {
@@ -614,7 +641,18 @@ impl Motives for GraphLaplacian {
         // Output vecs are already sorted from canonicalisation above.
         let mut out: Vec<Vec<usize>> = deduped_items;
         out.shrink_to_fit();
-        out
+        Ok(out)
+    }
+
+    fn spot_motives_energy(
+        &self,
+        aspace: &crate::core::ArrowSpace,
+        cfg: &MotiveConfig,
+    ) -> Vec<Vec<usize>> {
+        self.try_spot_motives_energy(aspace, cfg).expect(
+            "spot_motives_energy requires an energy build with sub_centroids \
+             and centroid_map; use try_spot_motives_energy for a typed error",
+        )
     }
 
     fn is_clique(&self, set: &HashSet<usize>) -> bool {

--- a/src/analysis/subgraphs/mod.rs
+++ b/src/analysis/subgraphs/mod.rs
@@ -44,6 +44,9 @@ pub struct Subgraph {
     pub laplacian: GraphLaplacian,
 
     /// Cached Rayleigh cohesion indicator (lower = more cohesive).
+    ///
+    /// Computed only when [`SubgraphConfig::rayleigh_max`] is `Some` at
+    /// extraction time. `None` means "not computed", not "not applicable".
     pub rayleigh: Option<f64>,
 }
 
@@ -51,8 +54,27 @@ pub struct Subgraph {
 pub trait SubgraphsMotive {
     /// Spot subgraphs using energy-mode motif detection with item mapping.
     ///
-    /// This wraps `spotmotivesenergy`, operating on subcentroids and mapping
-    /// back to original item indices via `ArrowSpace.centroid_map`.
+    /// This wraps `try_spot_motives_energy`, operating on subcentroids and
+    /// mapping back to original item indices via `ArrowSpace.centroid_map`.
+    ///
+    /// Requirements (enforced — returns
+    /// [`ArrowSpaceError::EnergyModeRequired`](crate::error::ArrowSpaceError::EnergyModeRequired)
+    /// on violation): the Laplacian must come from `build_energy` and the
+    /// index must carry `sub_centroids` and `centroid_map`. The historical
+    /// `cluster_assignments` fallback was removed in #161: it joins motifs
+    /// detected in one namespace (features or subcentroids) to a mapping in
+    /// another (items → clusters) and cannot produce correct results.
+    fn try_spot_subg_motives(
+        &self,
+        aspace: &ArrowSpace,
+        cfg: &SubgraphConfig,
+    ) -> Result<Vec<Subgraph>, crate::error::ArrowSpaceError>;
+
+    /// Panicking twin of [`SubgraphsMotive::try_spot_subg_motives`].
+    #[deprecated(
+        since = "0.27.3",
+        note = "use try_spot_subg_motives; this panics on non-energy builds"
+    )]
     fn spot_subg_motives(&self, aspace: &ArrowSpace, cfg: &SubgraphConfig) -> Vec<Subgraph>;
 }
 

--- a/src/analysis/subgraphs/sg_from_motives.rs
+++ b/src/analysis/subgraphs/sg_from_motives.rs
@@ -118,14 +118,21 @@ impl Subgraph {
 }
 
 impl SubgraphsMotive for GraphLaplacian {
-    fn spot_subg_motives(&self, aspace: &ArrowSpace, cfg: &SubgraphConfig) -> Vec<Subgraph> {
+    fn try_spot_subg_motives(
+        &self,
+        aspace: &ArrowSpace,
+        cfg: &SubgraphConfig,
+    ) -> Result<Vec<Subgraph>, crate::error::ArrowSpaceError> {
+        use crate::error::ArrowSpaceError;
+
         info!(
             "Spotting subgraphs with motives: topl={}, mintri={}, minsize={}",
             cfg.motives.top_l, cfg.motives.min_triangles, cfg.min_size
         );
 
         // 1. Run energy motif detection (subcentroid space → item space).
-        let item_motifs: Vec<Vec<usize>> = self.spot_motives_energy(aspace, &cfg.motives);
+        //    Propagates EnergyModeRequired if the build is not energy-mode.
+        let item_motifs: Vec<Vec<usize>> = self.try_spot_motives_energy(aspace, &cfg.motives)?;
 
         info!(
             "Motif detection returned {} item-space candidates",
@@ -133,17 +140,18 @@ impl SubgraphsMotive for GraphLaplacian {
         );
 
         // 2. Map item indices → centroid indices for each motif.
-        let centroid_map = if let Some(ref cmap) = aspace.centroid_map {
-            cmap.as_slice()
-        } else if !aspace.cluster_assignments.is_empty() {
-            let temp_map: Vec<usize> = aspace
-                .cluster_assignments
-                .iter()
-                .map(|&opt| opt.unwrap_or(0))
-                .collect();
-            Box::leak(temp_map.into_boxed_slice())
-        } else {
-            panic!("centroid_map or cluster_assignments required for energy subgraphs");
+        //
+        // centroid_map is required: the historical cluster_assignments
+        // fallback joined motifs detected in feature/subcentroid space to an
+        // items→clusters mapping — a different namespace — and could only
+        // produce garbage (issue #161).
+        let centroid_map: &[usize] = match &aspace.centroid_map {
+            Some(cmap) => cmap.as_slice(),
+            None => {
+                return Err(ArrowSpaceError::EnergyModeRequired {
+                    missing: "centroid_map on the ArrowSpace index",
+                });
+            }
         };
 
         let (_f_parent, n_centroids) = self.init_data.shape();
@@ -211,7 +219,14 @@ impl SubgraphsMotive for GraphLaplacian {
             cfg.rayleigh_max
         );
 
-        subgraphs
+        Ok(subgraphs)
+    }
+
+    fn spot_subg_motives(&self, aspace: &ArrowSpace, cfg: &SubgraphConfig) -> Vec<Subgraph> {
+        self.try_spot_subg_motives(aspace, cfg).expect(
+            "spot_subg_motives requires an energy build with sub_centroids \
+             and centroid_map; use try_spot_subg_motives for a typed error",
+        )
     }
 }
 

--- a/src/analysis/subgraphs/tests/test_subg_motives.rs
+++ b/src/analysis/subgraphs/tests/test_subg_motives.rs
@@ -1,10 +1,28 @@
 use crate::analysis::motives::MotiveConfig;
 use crate::analysis::subgraphs::{Subgraph, SubgraphConfig, SubgraphsMotive};
 use crate::builder::ArrowSpaceBuilder;
+use crate::error::ArrowSpaceError;
+use crate::maps::energymaps::{EnergyMapsBuilder, EnergyParams};
 use crate::tests::test_data::make_gaussian_cliques_multi;
 
 use log::debug;
 use smartcore::linalg::basic::arrays::Array;
+
+/// Build an energy-mode fixture: 300 points, 10 cliques, 100 dims.
+///
+/// `spot_subg_motives` requires an EnergyMaps build (issue #161): the
+/// pipeline needs `sub_centroids` and `centroid_map`, and `build_energy`
+/// requires dimensionality reduction to be enabled.
+fn energy_fixture() -> (crate::core::ArrowSpace, crate::graph::GraphLaplacian) {
+    let rows = make_gaussian_cliques_multi(300, 0.2, 10, 100, 999);
+    let mut builder = ArrowSpaceBuilder::new()
+        .with_lambda_graph(0.4, 12, 8, 2.0, None)
+        .with_seed(999)
+        .with_dims_reduction(true, Some(0.3))
+        .with_inline_sampling(None);
+    let p = EnergyParams::new(&builder);
+    builder.build_energy(rows, p)
+}
 
 #[test]
 fn test_subgraph_from_parent() {
@@ -62,14 +80,36 @@ fn test_subgraph_rayleigh_computation() {
 }
 
 #[test]
+fn test_try_spot_subg_motives_rejects_eigenmaps_build() {
+    crate::init();
+
+    // Issue #161: EigenMaps builds lack sub_centroids/centroid_map; the
+    // energy subgraph path must return a typed error, not degrade to
+    // feature-space motif detection mislabelled as items.
+    let rows = make_gaussian_cliques_multi(48, 0.2, 4, 120, 3407);
+    let (aspace, gl) = ArrowSpaceBuilder::new()
+        .with_lambda_graph(0.4, 12, 8, 2.0, None)
+        .with_seed(3407)
+        .build(rows);
+
+    let cfg = SubgraphConfig {
+        min_size: 3,
+        ..Default::default()
+    };
+    let err = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect_err("EigenMaps builds must be rejected");
+    assert!(
+        matches!(err, ArrowSpaceError::EnergyModeRequired { .. }),
+        "expected EnergyModeRequired, got: {err}"
+    );
+}
+
+#[test]
 fn test_spot_subgraphs_energy_basic() {
     crate::init();
 
-    let rows = make_gaussian_cliques_multi(300, 0.2, 10, 100, 999);
-    let (aspace, gl) = ArrowSpaceBuilder::new()
-        .with_lambda_graph(0.4, 12, 8, 2.0, None)
-        .with_seed(999)
-        .build(rows);
+    let (aspace, gl) = energy_fixture();
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -84,7 +124,9 @@ fn test_spot_subgraphs_energy_basic() {
         min_size: 5,
     };
 
-    let subgraphs = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     if subgraphs.is_empty() {
         debug!("No subgraphs extracted (may need different params)");
@@ -133,12 +175,7 @@ fn test_spot_subgraphs_energy_basic() {
 fn test_spot_subgraphs_energy_with_item_mapping() {
     crate::init();
 
-    let rows = make_gaussian_cliques_multi(300, 0.2, 10, 100, 999);
-    let builder = ArrowSpaceBuilder::new()
-        .with_lambda_graph(0.4, 12, 8, 2.0, None)
-        .with_seed(999);
-
-    let (aspace, gl) = builder.build(rows);
+    let (aspace, gl) = energy_fixture();
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -153,7 +190,9 @@ fn test_spot_subgraphs_energy_with_item_mapping() {
         min_size: 5,
     };
 
-    let subgraphs = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     if subgraphs.is_empty() {
         debug!("No energy subgraphs extracted");
@@ -210,13 +249,7 @@ fn test_spot_subgraphs_energy_with_item_mapping() {
 fn test_spot_subgraphs_energy_multi_motifs() {
     crate::init();
 
-    // 300 points, 10 cliques, tight clusters, 50 dimensions → expect ~10 motifs
-    let rows = make_gaussian_cliques_multi(300, 0.2, 10, 100, 999);
-
-    let (aspace, gl) = ArrowSpaceBuilder::new()
-        .with_lambda_graph(0.35, 14, 10, 2.0, None)
-        .with_seed(999)
-        .build(rows);
+    let (aspace, gl) = energy_fixture();
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -231,7 +264,9 @@ fn test_spot_subgraphs_energy_multi_motifs() {
         min_size: 6,
     };
 
-    let subgraphs = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     if subgraphs.len() < 2 {
         debug!(
@@ -288,11 +323,7 @@ fn test_spot_subgraphs_energy_multi_motifs() {
 fn test_subgraph_energy_rayleigh_filter() {
     crate::init();
 
-    let rows = make_gaussian_cliques_multi(300, 0.2, 10, 100, 999);
-    let (aspace, gl) = ArrowSpaceBuilder::new()
-        .with_lambda_graph(0.4, 12, 8, 2.0, None)
-        .with_seed(999)
-        .build(rows);
+    let (aspace, gl) = energy_fixture();
 
     // Strict Rayleigh filter to test filtering behavior.
     let cfg_strict = SubgraphConfig {
@@ -308,7 +339,9 @@ fn test_subgraph_energy_rayleigh_filter() {
         min_size: 5,
     };
 
-    let subgraphs_strict = gl.spot_subg_motives(&aspace, &cfg_strict);
+    let subgraphs_strict = gl
+        .try_spot_subg_motives(&aspace, &cfg_strict)
+        .expect("energy build must satisfy energy-mode requirements");
 
     // Relaxed Rayleigh filter.
     let cfg_relaxed = SubgraphConfig {
@@ -316,7 +349,9 @@ fn test_subgraph_energy_rayleigh_filter() {
         ..cfg_strict
     };
 
-    let subgraphs_relaxed = gl.spot_subg_motives(&aspace, &cfg_relaxed);
+    let subgraphs_relaxed = gl
+        .try_spot_subg_motives(&aspace, &cfg_relaxed)
+        .expect("energy build must satisfy energy-mode requirements");
 
     // Relaxed filter should yield >= strict filter results.
     assert!(
@@ -335,11 +370,7 @@ fn test_subgraph_energy_rayleigh_filter() {
 fn test_subgraph_structure_clique_data() {
     crate::init();
 
-    let rows = make_gaussian_cliques_multi(200, 0.3, 6, 100, 999);
-    let (aspace, gl) = ArrowSpaceBuilder::new()
-        .with_lambda_graph(0.35, 14, 10, 2.0, None)
-        .with_seed(999)
-        .build(rows);
+    let (aspace, gl) = energy_fixture();
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -354,7 +385,9 @@ fn test_subgraph_structure_clique_data() {
         min_size: 8, // minimum ITEM count
     };
 
-    let subgraphs = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     if subgraphs.is_empty() {
         debug!("No subgraphs extracted with these strict parameters");

--- a/src/analysis/subgraphs/tests/test_subg_parallel.rs
+++ b/src/analysis/subgraphs/tests/test_subg_parallel.rs
@@ -3,6 +3,7 @@ use crate::analysis::subgraphs::{
     CentroidGraphParams, MotiveConfig, SubgraphConfig, SubgraphsCentroid, SubgraphsMotive,
 };
 use crate::builder::ArrowSpaceBuilder;
+use crate::maps::energymaps::{EnergyMapsBuilder, EnergyParams};
 use crate::tests::test_data::make_gaussian_cliques_multi;
 
 use log::debug;
@@ -72,10 +73,13 @@ fn test_motif_subgraphs_parallel_correctness() {
     crate::init();
 
     let rows = make_gaussian_cliques_multi(200, 0.3, 6, 100, 999);
-    let (aspace, gl) = ArrowSpaceBuilder::new()
+    let mut builder = ArrowSpaceBuilder::new()
         .with_lambda_graph(0.35, 12, 8, 2.0, None)
         .with_seed(999)
-        .build(rows);
+        .with_dims_reduction(true, Some(0.3))
+        .with_inline_sampling(None);
+    let p = EnergyParams::new(&builder);
+    let (aspace, gl) = builder.build_energy(rows, p);
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -90,8 +94,12 @@ fn test_motif_subgraphs_parallel_correctness() {
         min_size: 5,
     };
 
-    let subgraphs1 = gl.spot_subg_motives(&aspace, &cfg);
-    let subgraphs2 = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs1 = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
+    let subgraphs2 = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     // --- Structural invariants: must hold independently on each run ---
     let f_parent = gl.init_data.shape().0;
@@ -338,10 +346,13 @@ fn test_motif_subgraphs_no_loss_or_duplication() {
     crate::init();
 
     let rows = make_gaussian_cliques_multi(250, 0.25, 8, 50, 777);
-    let (aspace, gl) = ArrowSpaceBuilder::new()
+    let mut builder = ArrowSpaceBuilder::new()
         .with_lambda_graph(0.35, 14, 10, 2.0, None)
         .with_seed(777)
-        .build(rows);
+        .with_dims_reduction(true, Some(0.3))
+        .with_inline_sampling(None);
+    let p = EnergyParams::new(&builder);
+    let (aspace, gl) = builder.build_energy(rows, p);
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -356,7 +367,9 @@ fn test_motif_subgraphs_no_loss_or_duplication() {
         min_size: 6,
     };
 
-    let subgraphs = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     if subgraphs.is_empty() {
         debug!("No subgraphs extracted; skipping duplication check");
@@ -450,10 +463,13 @@ fn test_parallel_stress_large_dataset() {
     crate::init();
 
     let rows = make_gaussian_cliques_multi(500, 0.2, 10, 100, 1234);
-    let (aspace, gl) = ArrowSpaceBuilder::new()
+    let mut builder = ArrowSpaceBuilder::new()
         .with_lambda_graph(0.3, 16, 12, 2.0, None)
         .with_seed(1234)
-        .build(rows);
+        .with_dims_reduction(true, Some(0.3))
+        .with_inline_sampling(None);
+    let p = EnergyParams::new(&builder);
+    let (aspace, gl) = builder.build_energy(rows, p);
 
     let cfg = SubgraphConfig {
         motives: MotiveConfig {
@@ -469,7 +485,9 @@ fn test_parallel_stress_large_dataset() {
     };
 
     // Should complete without hanging or panicking
-    let subgraphs = gl.spot_subg_motives(&aspace, &cfg);
+    let subgraphs = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     // Basic sanity checks
     for sg in &subgraphs {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,21 @@ pub enum ArrowSpaceError {
 
     /// The item matrix passed to the builder is empty.
     EmptyItems,
+
+    /// The operation requires an EnergyMaps build, but the target lacks
+    /// energy-mode bookkeeping.
+    ///
+    /// Triggered by `try_spot_motives_energy` / `try_spot_subg_motives` when
+    /// the Laplacian was not built via `build_energy`, or the index carries no
+    /// `sub_centroids` / `centroid_map`. Running energy motif detection on an
+    /// EigenMaps build would silently operate on feature-space nodes and
+    /// mislabel them as item indices (issue #161), so the operation refuses
+    /// instead of degrading.
+    EnergyModeRequired {
+        /// What is missing, as a human-readable fragment (e.g. `"energy build
+        /// (use build_energy)"`, `"sub_centroids"`, `"centroid_map"`).
+        missing: &'static str,
+    },
 }
 
 impl fmt::Display for ArrowSpaceError {
@@ -73,6 +88,14 @@ impl fmt::Display for ArrowSpaceError {
                 "dimension mismatch: expected {expected} features, got {got}"
             ),
             Self::EmptyItems => write!(f, "items cannot be empty"),
+            Self::EnergyModeRequired { missing } => write!(
+                f,
+                "energy mode required: missing {missing}. Build via \
+                 EnergyMapsBuilder::build_energy so sub_centroids and \
+                 centroid_map are populated; running energy motif detection \
+                 on an EigenMaps build would mislabel feature-space indices \
+                 as item indices."
+            ),
         }
     }
 }

--- a/src/tests/test_motives.rs
+++ b/src/tests/test_motives.rs
@@ -1,4 +1,5 @@
 use crate::analysis::motives::{MotiveConfig, Motives};
+use crate::analysis::subgraphs::SubgraphsMotive;
 use crate::builder::ArrowSpaceBuilder;
 use crate::maps::energymaps::{EnergyMapsBuilder, EnergyParams};
 use crate::tests::test_data::make_gaussian_cliques;
@@ -103,7 +104,9 @@ fn test_motives_energy_basic() {
         jaccard_dedup: 0.8,
     };
 
-    let motifs = gl_energy.spot_motives_energy(&aspace, &cfg);
+    let motifs = gl_energy
+        .try_spot_motives_energy(&aspace, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
 
     info!("Found {} motifs (energy):", motifs.len());
     for (i, m) in motifs.iter().enumerate() {
@@ -162,7 +165,9 @@ fn test_motives_eigen_vs_energy_consistency() {
         .build_energy(rows, p);
 
     // Energy-aware motifs: discovered on subcentroid graph, mapped to items
-    let motifs_eng = gl_eng.spot_motives_energy(&aspace_eng, &cfg);
+    let motifs_eng = gl_eng
+        .try_spot_motives_energy(&aspace_eng, &cfg)
+        .expect("energy build must satisfy energy-mode requirements");
     debug!("Eigen motifs ({}): {:?}", motifs_eig.len(), motifs_eig);
     debug!("Energy motifs ({}): {:?}", motifs_eng.len(), motifs_eng);
     assert!(
@@ -287,7 +292,9 @@ fn test_motives_energy_stable() {
             max_sets: 64,
             jaccard_dedup: 0.8,
         };
-        gl_eng.spot_motives_energy(&aspace_eng, &cfg)
+        gl_eng
+            .try_spot_motives_energy(&aspace_eng, &cfg)
+            .expect("energy build must satisfy energy-mode requirements")
     };
 
     for motifs in [build(), build()] {
@@ -303,6 +310,99 @@ fn test_motives_energy_stable() {
                 m
             );
         }
+    }
+}
+
+#[test]
+fn test_spot_subg_motives_eigenmaps_must_not_return_feature_indices() {
+    use crate::error::ArrowSpaceError;
+
+    crate::tests::init();
+
+    // Issue #161 regression guard: on an EigenMaps build (no sub_centroids,
+    // no centroid_map) spot_subg_motives used to run motif detection over the
+    // F×F bootstrap Laplacian — whose nodes enumerate FEATURES — and label
+    // the results as item_indices. With N=48 items and F=120 features the
+    // namespaces cannot be confused: the pre-fix failure returned ids in
+    // 9..=117 on this exact fixture. The fix rejects the call instead.
+    let rows = crate::tests::test_data::make_gaussian_cliques_multi(48, 0.2, 4, 120, 3407);
+    let (aspace, gl) = ArrowSpaceBuilder::new()
+        .with_lambda_graph(0.4, 12, 8, 2.0, None)
+        .with_seed(3407)
+        .build(rows);
+
+    let cfg = crate::analysis::subgraphs::SubgraphConfig {
+        min_size: 3,
+        ..Default::default()
+    };
+    let err = gl
+        .try_spot_subg_motives(&aspace, &cfg)
+        .expect_err("EigenMaps builds must be rejected, not served feature-space indices");
+    assert!(
+        matches!(err, ArrowSpaceError::EnergyModeRequired { .. }),
+        "expected EnergyModeRequired, got: {err}"
+    );
+}
+
+#[test]
+fn test_try_spot_motives_energy_rejects_eigenmaps_build() {
+    use crate::error::ArrowSpaceError;
+
+    crate::tests::init();
+
+    // Issue #161: the energy path must refuse EigenMaps builds instead of
+    // silently degrading to feature-space motif detection.
+    let rows = make_gaussian_cliques(12, 0.04, 12, 10, 3407);
+    let (aspace, gl) = ArrowSpaceBuilder::new()
+        .with_seed(3407)
+        .with_lambda_graph(0.4, 14, 8, 2.0, None)
+        .with_inline_sampling(None)
+        .build(rows);
+
+    let cfg = MotiveConfig::default();
+    let err = gl
+        .try_spot_motives_energy(&aspace, &cfg)
+        .expect_err("EigenMaps builds must be rejected");
+    assert!(
+        matches!(err, ArrowSpaceError::EnergyModeRequired { .. }),
+        "expected EnergyModeRequired, got: {err}"
+    );
+}
+
+#[test]
+fn test_try_spot_motives_energy_returns_item_space_indices() {
+    crate::tests::init();
+
+    // On a genuine energy build the fallible path succeeds and every motif
+    // index lives in item space (0..nitems), never in subcentroid space.
+    let rows = make_gaussian_cliques(12, 0.04, 12, 10, 3407);
+    let mut builder = ArrowSpaceBuilder::new()
+        .with_seed(3407)
+        .with_lambda_graph(0.35, 18, 10, 2.0, None)
+        .with_dims_reduction(true, Some(0.3))
+        .with_inline_sampling(None);
+    let p = crate::maps::energymaps::EnergyParams::new(&builder);
+    let (aspace, gl) = builder.build_energy(rows, p);
+
+    let cfg = MotiveConfig {
+        top_l: 16,
+        min_triangles: 2,
+        min_clust: 0.35,
+        max_motif_size: 24,
+        max_sets: 64,
+        jaccard_dedup: 0.8,
+    };
+    let motifs = gl
+        .try_spot_motives_energy(&aspace, &cfg)
+        .expect("energy build must satisfy the energy-mode requirements");
+
+    assert!(!motifs.is_empty(), "energy pipeline returned no motifs");
+    for m in &motifs {
+        assert!(
+            m.iter().all(|&i| i < aspace.nitems),
+            "motif {m:?} leaves item space 0..{}",
+            aspace.nitems
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

`Motives::spot_motives_energy` and `SubgraphsMotive::spot_subg_motives` document hard requirements — energy build, `sub_centroids`, `centroid_map` — but the implementation enforced none of them. On an EigenMaps build (or any build without subcentroid bookkeeping) both returned **feature-space indices labelled as `item_indices`**, silently violating the module's own documented invariants.

Following the direction set by #121/#153, the fix adds fallible `try_*` variants that enforce the contract and deprecates the panicking twins instead of changing their signatures.

## Reproduction (pre-fix)

EigenMaps build, N=48 items × F=120 features (namespaces cannot be confused), then `spot_subg_motives`:

```
item_indices: min=9, max=117  →  feature space (0..F-1), not items (0..N-1)
```

119 > 48 cannot be item indices. Regression test added on this exact fixture.

## Changes

- **`ArrowSpaceError::EnergyModeRequired { missing }`** — new typed error variant with a fragment naming what is missing.
- **`Motives::try_spot_motives_energy`** — enforces `self.energy`, `aspace.sub_centroids`, `aspace.centroid_map`; returns `Err` instead of degrading. `spot_motives_energy` remains as a `#[deprecated(since = "0.27.3")]` panicking wrapper.
- **`SubgraphsMotive::try_spot_subg_motives`** — requires `centroid_map`; `spot_subg_motives` deprecated identically.
- **Removed the `cluster_assignments` fallback** in `sg_from_motives.rs`: it "projected" motifs detected in feature/subcentroid space through an items→clusters mapping — a different namespace — so it could only produce garbage. It also `Box::leak`ed on every call.
- **Documented** the `rayleigh`/`rayleigh_max` coupling on `Subgraph::rayleigh` (`None` = not computed, not "not applicable").
- **Tests**: migrated 8 tests that unknowingly exercised the silent EigenMaps path to `build_energy` fixtures; added rejection (`Err(EnergyModeRequired)`) and item-space regression tests. Version bumped to 0.27.3.

## Verification

- Full suite: `cargo test --release --lib` → **287 passed, 0 failed**
- `cargo clippy --all-targets`: no new warnings from this change (remaining ones pre-date it)
- `cargo fmt --check`: clean on all touched files
- Binding note: pyarrowspace's `spot_subg_motives` entry point (no guard there, unlike `spot_motives_energy`) will now panic → `PanicException` on EigenMaps builds instead of returning garbage; a binding-level migration to `try_*` can map it to a clean `ValueError` in a follow-up pyarrowspace PR.

Fixes #161