### PR TITLE
feat(builder): typed InvalidConfig errors for build_energy misconfiguration (#155)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,7 @@ use std::fmt;
 /// | `NonFiniteQuery` | The query vector contains `NaN` or `±Infinity`. |
 /// | `DimensionMismatch` | The query vector's length differs from the index's feature count. |
 /// | `EmptyItems` | The item matrix passed to the builder is empty. |
+/// | `InvalidConfig` | The builder configuration is invalid for the requested pipeline (e.g. energy build without dims reduction). |
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArrowSpaceError {
     /// The spectral score (lambda) computed for a query — or stored on a query
@@ -53,6 +54,17 @@ pub enum ArrowSpaceError {
 
     /// The item matrix passed to the builder is empty.
     EmptyItems,
+
+    /// The builder configuration is invalid for the requested pipeline.
+    ///
+    /// Triggered by `try_build_energy` when the builder lacks dims reduction
+    /// or carries the (experimental, unimplemented) spectral flag. Replaces
+    /// the `assert!`/`panic!` the energy build path used before (#155) so
+    /// misconfiguration surfaces as a typed error instead of a process abort.
+    InvalidConfig {
+        /// What is wrong with the configuration, as a human-readable fragment.
+        reason: &'static str,
+    },
 
     /// The operation requires an EnergyMaps build, but the target lacks
     /// energy-mode bookkeeping.
@@ -88,6 +100,9 @@ impl fmt::Display for ArrowSpaceError {
                 "dimension mismatch: expected {expected} features, got {got}"
             ),
             Self::EmptyItems => write!(f, "items cannot be empty"),
+            Self::InvalidConfig { reason } => {
+                write!(f, "invalid configuration: {reason}")
+            }
             Self::EnergyModeRequired { missing } => write!(
                 f,
                 "energy mode required: missing {missing}. Build via \

--- a/src/maps/energymaps.rs
+++ b/src/maps/energymaps.rs
@@ -1051,7 +1051,33 @@ fn node_energy_and_dispersion(
 /// Extends ArrowSpaceBuilder with methods to build energy-aware Laplacian graphs
 /// that remove cosine similarity dependence from both construction and search.
 pub trait EnergyMapsBuilder {
+    /// Build ArrowSpace using the energy-only pipeline (no cosine), with
+    /// configuration validation.
+    ///
+    /// Fallible variant of [`EnergyMapsBuilder::build_energy`]: returns
+    /// [`ArrowSpaceError::InvalidConfig`](crate::error::ArrowSpaceError::InvalidConfig)
+    /// instead of panicking when the builder state cannot run the energy
+    /// pipeline (dims reduction disabled, or the experimental spectral flag
+    /// enabled — see #156 for the spectral feature itself).
+    ///
+    /// # Arguments
+    /// * `rows` - Input dataset (N × F)
+    /// * `energy_params` - Parameters controlling energy pipeline stages
+    ///
+    /// # Returns
+    /// Tuple of (ArrowSpace with energy-computed lambdas, energy-only GraphLaplacian)
+    fn try_build_energy(
+        &mut self,
+        rows: Vec<Vec<f64>>,
+        energy_params: EnergyParams,
+    ) -> Result<(ArrowSpace, GraphLaplacian), crate::error::ArrowSpaceError>;
+
     /// Build ArrowSpace using energy-only pipeline (no cosine).
+    ///
+    /// Panicking twin of [`EnergyMapsBuilder::try_build_energy`]; kept
+    /// non-deprecated because it is load-bearing for the PyO3 bindings.
+    /// Misconfiguration (e.g. dims reduction disabled) aborts the process —
+    /// prefer the `try_` variant in Rust callers.
     ///
     /// # Arguments
     /// * `rows` - Input dataset (N × F)
@@ -1115,19 +1141,27 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
     ///    ranking during search.
     /// 7. ...
     /// 8. ...
-    fn build_energy(
+    fn try_build_energy(
         &mut self,
         rows: Vec<Vec<f64>>,
         energy_params: EnergyParams,
-    ) -> (ArrowSpace, GraphLaplacian) {
-        assert!(
-            self.use_dims_reduction,
-            "When using build_energy, dim reduction is needed"
-        );
+    ) -> Result<(ArrowSpace, GraphLaplacian), crate::error::ArrowSpaceError> {
+        use crate::error::ArrowSpaceError;
+
+        // Configuration validation (#155): typed errors instead of process
+        // aborts. The spectral flag is tracked in #156; until it is
+        // implemented the combination stays rejected.
+        if !self.use_dims_reduction {
+            return Err(ArrowSpaceError::InvalidConfig {
+                reason: "dim reduction is needed: enable with_dims_reduction(true, ..) \
+                         before build_energy",
+            });
+        }
         if self.prebuilt_spectral {
-            panic!(
-                "Spectral mode not compatible with build_energy, please do not enable for energy search"
-            );
+            return Err(ArrowSpaceError::InvalidConfig {
+                reason: "spectral mode is not compatible with build_energy, \
+                         please do not enable it for energy search",
+            });
         }
         self.nitems = rows.len();
         self.nfeatures = rows[0].len();
@@ -1391,7 +1425,18 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
             aspace.item_norms.as_ref().unwrap().iter().sum::<f64>() / aspace.nitems as f64
         );
 
-        (aspace, gl_energy)
+        Ok((aspace, gl_energy))
+    }
+
+    fn build_energy(
+        &mut self,
+        rows: Vec<Vec<f64>>,
+        energy_params: EnergyParams,
+    ) -> (ArrowSpace, GraphLaplacian) {
+        self.try_build_energy(rows, energy_params).expect(
+            "build_energy misconfigured: dims reduction is required and spectral mode \
+             is not supported; use try_build_energy for a typed error",
+        )
     }
 
     /// Build the RFxRF (reduced-features) energy laplacian

--- a/src/tests/test_energy_builder.rs
+++ b/src/tests/test_energy_builder.rs
@@ -2,6 +2,7 @@
 #![cfg(test)]
 
 use crate::builder::ArrowSpaceBuilder;
+use crate::error::ArrowSpaceError;
 use crate::graph::GraphLaplacian;
 use crate::maps::energymaps::{EnergyMapsBuilder, EnergyParams};
 use crate::search::taumode::TauMode;
@@ -9,6 +10,59 @@ use log::{debug, info};
 use smartcore::linalg::basic::arrays::Array;
 
 use crate::tests::test_data::{make_gaussian_hd, make_moons_hd};
+
+#[test]
+fn test_try_build_energy_rejects_missing_dims_reduction() {
+    crate::tests::init();
+
+    // Issue #155: a misconfigured builder must produce a typed error, not a
+    // process abort. Dims reduction is off by default, so a fresh builder is
+    // the misconfiguration case.
+    let rows = make_gaussian_hd(100, 0.2);
+    let mut builder = ArrowSpaceBuilder::new().with_seed(3407);
+    let p = EnergyParams::new(&builder);
+
+    let err = builder
+        .try_build_energy(rows, p)
+        .expect_err("default builder lacks dims reduction and must be rejected");
+    assert!(
+        matches!(err, ArrowSpaceError::InvalidConfig { .. }),
+        "expected InvalidConfig, got: {err}"
+    );
+}
+
+#[test]
+fn test_try_build_energy_accepts_valid_config() {
+    crate::tests::init();
+
+    // The fallible path returns the same artifact the panicking twin builds.
+    let rows = make_gaussian_hd(100, 0.2);
+    let mut builder = ArrowSpaceBuilder::new()
+        .with_seed(3407)
+        .with_dims_reduction(true, Some(0.3))
+        .with_inline_sampling(None);
+    let p = EnergyParams::new(&builder);
+
+    let (aspace, gl) = builder
+        .try_build_energy(rows, p)
+        .expect("valid config must build");
+    assert!(aspace.nitems > 0);
+    assert!(gl.energy);
+    assert!(aspace.lambdas.iter().any(|&l| l != 0.0));
+}
+
+#[test]
+#[should_panic(expected = "dim reduction is needed")]
+fn test_build_energy_still_panics_on_misconfiguration() {
+    crate::tests::init();
+
+    // build_energy stays a documented panicking wrapper (load-bearing for the
+    // PyO3 bindings); its failure mode must not change.
+    let rows = make_gaussian_hd(100, 0.2);
+    let mut builder = ArrowSpaceBuilder::new().with_seed(3407);
+    let p = EnergyParams::new(&builder);
+    let _ = builder.build_energy(rows, p);
+}
 
 #[test]
 fn test_energy_build_basic() {
@@ -406,7 +460,7 @@ fn test_build_energy_dimensionality_reduction() {
 }
 
 #[test]
-#[should_panic(expected = "When using build_energy, dim reduction is needed")]
+#[should_panic(expected = "dim reduction is needed")]
 fn test_build_energy_requires_dims_reduction() {
     let rows: Vec<Vec<f64>> = vec![vec![1.0; 128]; 100];
 


### PR DESCRIPTION
## Summary

`EnergyMapsBuilder::build_energy` validated its configuration with `assert!`/`panic!`, so a misconfigured caller (dims reduction disabled, or the experimental spectral flag enabled) got a **process abort** instead of an error — the same failure class already fixed for the query path in #122/#153.

## Changes

- **`ArrowSpaceError::InvalidConfig { reason }`** — new variant for builder misconfiguration.
- **`EnergyMapsBuilder::try_build_energy(rows, energy_params) -> Result<(ArrowSpace, GraphLaplacian), ArrowSpaceError>`** — performs the same validation as typed errors before any pipeline work runs. Mid-pipeline invariant checks (projection consistency) stay `assert!`s: they are invariant violations, not recoverable input conditions, per the `error.rs` contract.
- **`build_energy` kept as a documented panicking wrapper** — deliberately **not** deprecated: it is load-bearing for the PyO3 bindings (`pyarrowspace/src/lib.rs:990`), and #155's proposal allows either option. The wrapper now delegates to `try_build_energy`, so both entry points share one validation path.

## Scope notes

- The `prebuilt_spectral` branch maps to `InvalidConfig` with no behavioural change (still rejected). The spectral feature itself is tracked in **#156** — no spectral test surface here.
- One residual data-dependent panic remains in this path: `rows[0].len()` aborts on an empty item matrix (an existing `EmptyItems` variant would fit). Left out of this quick fix to keep the diff minimal — flag it if you want it folded in.

## Tests (TDD)

- `test_try_build_energy_rejects_missing_dims_reduction` — default builder (dims reduction off) → `Err(InvalidConfig)`; **failed to compile before the fix (RED)**, passes after
- `test_try_build_energy_accepts_valid_config` — happy path returns a working energy index
- `test_build_energy_still_panics_on_misconfiguration` — pins the wrapper's failure mode for bindings
- Existing `test_build_energy_requires_dims_reduction` updated: same intent (must panic), `expected` substring moved from the old `assert!` text to the new payload

Full suite: `cargo test --release --lib` → **290 passed, 0 failed**. Clippy clean on touched files; `cargo fmt --check` clean on touched files.

Fixes #155