### PR TITLE
fix(taumode): bit-reproducible Eigen λ — remove schedule-dependent par_bridge reduction (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to `arrowspace` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versions follow [SemVer](https://semver.org/).
 
+## [0.28.1] — fixed
+
+### Fixed — Eigen λ bit-reproducibility under pool load (#170)
+
+`TauMode::compute_rayleigh_quotient_from_matrix` reduced the Rayleigh
+numerator with `par_bridge().sum()`: `par_bridge` batches its source by
+dynamic work-stealing, so the f64 addends grouped in a schedule-dependent
+order — and f64 addition is not associative. When the global rayon pool was
+busy, two builds of identical input with identical configuration (same seed,
+`deterministic_clustering = true`) could return λ vectors differing by up to
+~1 ULP, breaking downstream consumers that pin stored λ by exact equality.
+
+The reduction is now deterministic by construction:
+
+- per-row partial terms are computed in parallel (each row's inner sum is a
+  sequential pass over its nonzeros in index order), collected into an
+  index-addressed buffer;
+- the numerator is a sequential fixed-order pass over the per-row terms;
+- the denominator (xᵀx) is a sequential fixed-order pass — the previous
+  parallel indexed reduce split by pool thread count, which made bits vary
+  across machine configurations.
+
+No summation grouping depends on thread scheduling any more: identical
+inputs produce bit-identical λ on any machine, any pool size, any load.
+This is a value-level change in the last bits only (the summation order
+changed); graph structure, clustering and λ semantics are untouched.
+
+The reproducibility contract is now documented on `with_seed` and
+`build_for_persistence`: seeded builds of identical input return
+byte-identical λ vectors, by construction rather than by tolerance.
+
+### Added — regression tests
+
+`test_rayleigh_quotient_bit_reproducible_under_pool_saturation` and
+`test_eigen_build_lambda_bit_reproducible_under_pool_saturation`
+(src/tests/test_lambda_determinism.rs) saturate the global rayon pool with
+CPU-bound work while measuring, and assert bit-identical Rayleigh quotients
+and byte-identical λ vectors across repeated builds. The unit test fails
+reliably on pre-#170 code (last-bit drift on the first loaded call).
+
 ## [0.28.0] — breaking
 
 This release fixes the `DenseMatrix` flat-buffer layout defect (#167):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -777,7 +777,15 @@ impl ArrowSpaceBuilder {
 
     /// Set a custom seed for deterministic clustering.
     /// Enable sequential (deterministic) clustering.
-    /// This ensures reproducible results at the cost of parallelization.
+    ///
+    /// # Reproducibility contract (issue #170)
+    ///
+    /// With a seed set, two builds of identical input rows with an identical
+    /// builder configuration return byte-identical λ vectors — bit-exact,
+    /// not approximate. This holds regardless of thread scheduling or global
+    /// rayon pool load: every float reduction in the λ read-out has a fixed
+    /// summation order (no work-stealing-driven grouping). Reproducibility
+    /// is by construction, not by tolerance.
     pub fn with_seed(mut self, seed: u64) -> Self {
         info!("Setting custom clustering seed: {}", seed);
         self.clustering_seed = Some(seed);
@@ -1114,6 +1122,11 @@ impl ArrowSpaceBuilder {
     /// [`EnergyParams`]. Use `"eigen".parse::<PipelineKind>()` in stringly
     /// contexts (CLI/serde) — an invalid name is an
     /// [`InvalidPipelineError`], not a runtime panic.
+    ///
+    /// Reproducibility: with a seed set via [`ArrowSpaceBuilder::with_seed`],
+    /// identical input and configuration produce byte-identical λ vectors
+    /// across builds, whatever the thread scheduling or pool load (#170) —
+    /// stored λ can be verified by exact equality after a rebuild.
     pub fn build_for_persistence(
         mut self,
         rows: DenseMatrix<f64>,
@@ -1252,17 +1265,13 @@ impl ArrowSpaceBuilder {
                 assert_eq!(centroids.shape().0, l0.nnodes, "l0 is still non-projected");
 
                 // Step 4: Diffuse and split to create sub_centroids
-                let sub_centroids: DenseMatrix<f64> = ArrowSpace::diffuse_and_split_subcentroids(
-                    &centroids,
-                    &l0,
-                    &energy_params,
-                );
+                let sub_centroids: DenseMatrix<f64> =
+                    ArrowSpace::diffuse_and_split_subcentroids(&centroids, &l0, &energy_params);
 
                 assert_eq!(sub_centroids.shape().1, centroids.shape().1);
 
                 // Step 6: Build Laplacian on sub_centroids using energy dispersion
-                let (gl_energy, _, _) =
-                    self.build_energy_laplacian(&sub_centroids, &energy_params);
+                let (gl_energy, _, _) = self.build_energy_laplacian(&sub_centroids, &energy_params);
 
                 assert_eq!(
                     gl_energy.shape().1,

--- a/src/search/taumode.rs
+++ b/src/search/taumode.rs
@@ -320,6 +320,16 @@ impl TauMode {
     /// - graph is F×F Laplacian (features × features)
     /// - item_vector is F-dimensional
     /// - i,j indices reference FEATURES, not items
+    ///
+    /// # Determinism (issue #170)
+    ///
+    /// Identical inputs produce bit-identical results regardless of thread
+    /// scheduling. Per-row partial terms are computed in parallel, but each
+    /// row's inner sum is a sequential pass over its nonzeros in index order,
+    /// and both reductions are sequential fixed-order passes over
+    /// index-addressed buffers. Schedule-dependent batching (`par_bridge`)
+    /// was removed: f64 addition is not associative, so work-stealing-driven
+    /// grouping drifted the quotient in the last bits.
     pub fn compute_rayleigh_quotient_from_matrix(matrix: &CsMat<f64>, vector: &[f64]) -> f64 {
         let n = vector.len();
 
@@ -333,22 +343,31 @@ impl TauMode {
             matrix.shape()
         );
 
-        // Compute x^T M x efficiently using sparse structure
-        let numerator: f64 = matrix
-            .outer_iterator() // Iterate over rows (CSR format)
-            .enumerate() // Get (row_idx, row_view) pairs
-            .par_bridge() // Parallelize
-            .map(|(i, row)| {
+        // x^T M x = Σ_i x_i · (Σ_j M_ij x_j).
+        // Parallelism is per-row only: each row's inner sum accumulates its
+        // nonzeros sequentially in index order (bits independent of the
+        // evaluating thread), and the collected per-row terms are summed in
+        // a fixed sequential order. No reduction grouping depends on
+        // scheduling.
+        let row_terms: Vec<f64> = (0..n)
+            .into_par_iter()
+            .map(|i| {
                 let xi = vector[i];
-
-                // row.iter() gives (col_idx, &value) for non-zero entries ONLY
-                row.iter()
-                    .map(|(j, &mij)| xi * mij * vector[j])
-                    .sum::<f64>()
+                let mut row_sum = 0.0f64;
+                if let Some(row) = matrix.outer_view(i) {
+                    for (j, &mij) in row.iter() {
+                        row_sum += xi * mij * vector[j];
+                    }
+                }
+                row_sum
             })
-            .sum();
+            .collect();
 
-        let denominator: f64 = vector.par_iter().map(|&x| x * x).sum();
+        let numerator: f64 = row_terms.iter().sum();
+
+        // Sequential fixed-order reduction: identical bits on any machine,
+        // any pool size (parallel indexed reduces split by thread count).
+        let denominator: f64 = vector.iter().map(|&x| x * x).sum();
 
         if denominator > 1e-12 {
             (numerator / denominator).max(0.0)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod test_eigenmaps;
 mod test_energy_builder;
 mod test_energy_search;
 mod test_graph_factory;
+mod test_lambda_determinism;
 mod test_laplacian;
 mod test_laplacian_scaling;
 mod test_laplacian_unnormalised;

--- a/src/tests/test_builder.rs
+++ b/src/tests/test_builder.rs
@@ -1,4 +1,3 @@
-
 // Exercises the deprecated panicking wrappers on purpose:
 // the backward-compat surface must keep its documented panic behaviour (#153).
 #![allow(deprecated)]
@@ -584,7 +583,10 @@ fn test_builder_unit_norm_diagonal_similarity() {
 
 #[test]
 fn test_pipeline_kind_from_str_parses_eigen_and_energy() {
-    assert_eq!("eigen".parse::<PipelineKind>().unwrap(), PipelineKind::Eigen);
+    assert_eq!(
+        "eigen".parse::<PipelineKind>().unwrap(),
+        PipelineKind::Eigen
+    );
     assert_eq!(
         "energy".parse::<PipelineKind>().unwrap(),
         PipelineKind::Energy(EnergyParams::default())

--- a/src/tests/test_energy_search.rs
+++ b/src/tests/test_energy_search.rs
@@ -1,4 +1,3 @@
-
 // Exercises the deprecated panicking wrappers on purpose:
 // the backward-compat surface must keep its documented panic behaviour (#153).
 #![allow(deprecated)]

--- a/src/tests/test_lambda_determinism.rs
+++ b/src/tests/test_lambda_determinism.rs
@@ -1,0 +1,192 @@
+//! Regression tests for issue #170: Eigen λ bit-reproducibility.
+//!
+//! `deterministic_clustering` (set by `ArrowSpaceBuilder::with_seed`) is
+//! documented as making builds reproducible, but the Rayleigh-quotient
+//! reduction in `TauMode::compute_rayleigh_quotient_from_matrix` used
+//! `par_bridge().sum()`. `par_bridge` batches its source by dynamic
+//! work-stealing, so the f64 addends group in a schedule-dependent order —
+//! and f64 addition is not associative. When the global rayon pool was busy,
+//! two builds of identical input with identical config diverged in the last
+//! bits of every λ.
+//!
+//! These tests saturate the global pool with CPU-bound work while the
+//! measured computations run on the same pool, then assert byte-identical
+//! (bit-exact) results. Scheduling may reorder *execution*, never the
+//! *grouping of the summation*.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use rayon::prelude::*;
+use serial_test::serial;
+use smartcore::linalg::basic::matrix::DenseMatrix;
+use sprs::TriMat;
+
+use crate::builder::{ArrowSpaceBuilder, PipelineKind};
+use crate::search::taumode::TauMode;
+use crate::tests::init;
+use crate::tests::test_data::make_gaussian_hd;
+
+/// Seeded LCG stream so every run exercises identical inputs.
+struct Lcg(u64);
+
+impl Lcg {
+    fn next_unit(&mut self) -> f64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 33) % 1_000_000) as f64 / 1_000_000.0
+    }
+}
+
+/// Fixed sparse Laplacian-like matrix (L = D − A) built from a seeded LCG.
+/// Ring + long-range connections, symmetric off-diagonal weights.
+fn fixed_laplacian(n: usize) -> sprs::CsMat<f64> {
+    let mut lcg = Lcg(0x2545_F491_4F6C_DD1D);
+    let mut degrees = vec![0.0f64; n];
+    let mut triplets: Vec<(usize, usize, f64)> = Vec::new();
+
+    for i in 0..n {
+        for step in [1usize, 7, 31] {
+            let j = (i + step) % n;
+            let w = 0.1 + lcg.next_unit();
+            triplets.push((i, j, -w));
+            triplets.push((j, i, -w));
+            degrees[i] += w;
+            degrees[j] += w;
+        }
+    }
+    for i in 0..n {
+        triplets.push((i, i, degrees[i]));
+    }
+
+    let mut tm = TriMat::new((n, n));
+    for (i, j, v) in triplets {
+        tm.add_triplet(i, j, v);
+    }
+    tm.to_csr()
+}
+
+/// Fixed query vector for the Rayleigh quotient, mixed magnitudes so the
+/// summation grouping matters in the last bits.
+fn fixed_vector(n: usize) -> Vec<f64> {
+    let mut lcg = Lcg(0xDEAD_BEEF_CAFE_1234);
+    (0..n).map(|_| 0.1 + 10.0 * lcg.next_unit()).collect()
+}
+
+/// Floods the global rayon pool with CPU-bound tasks from independent
+/// threads for the lifetime of the guard, so the code under test runs while
+/// the pool is saturated (the condition under which issue #170 manifests).
+struct PoolSaturator {
+    stop: Arc<AtomicBool>,
+    handles: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl PoolSaturator {
+    fn start() -> Self {
+        let workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+        let stop = Arc::new(AtomicBool::new(false));
+        let handles = (0..workers)
+            .map(|_| {
+                let stop = Arc::clone(&stop);
+                std::thread::spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        (0..64).into_par_iter().for_each(|_| {
+                            let mut x = 0.5f64;
+                            for _ in 0..20_000 {
+                                x = std::hint::black_box(x * 1.000_000_1 + 1e-9);
+                            }
+                            std::hint::black_box(x);
+                        });
+                    }
+                })
+            })
+            .collect();
+        PoolSaturator { stop, handles }
+    }
+}
+
+impl Drop for PoolSaturator {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Unit-level check: identical (matrix, vector) inputs must give a
+/// bit-identical Rayleigh quotient on every evaluation, even while the
+/// global pool is saturated by unrelated work. `par_bridge().sum()` batches
+/// by work-stealing, so this fails on issue #170.
+#[test]
+#[serial]
+fn test_rayleigh_quotient_bit_reproducible_under_pool_saturation() {
+    init();
+
+    let n = 200;
+    let matrix = fixed_laplacian(n);
+    let vector = fixed_vector(n);
+
+    // Reference evaluation on an idle pool.
+    let expected = TauMode::compute_rayleigh_quotient_from_matrix(&matrix, &vector);
+    assert!(
+        expected.is_finite() && expected > 0.0,
+        "fixture must produce a non-trivial quotient, got {expected}"
+    );
+
+    let _sat = PoolSaturator::start();
+    for call in 0..512 {
+        let got = TauMode::compute_rayleigh_quotient_from_matrix(&matrix, &vector);
+        assert_eq!(
+            expected.to_bits(),
+            got.to_bits(),
+            "Rayleigh quotient not bit-reproducible at call {call} under pool saturation: \
+             {expected:e} vs {got:e}"
+        );
+    }
+}
+
+/// Acceptance criterion from issue #170: two independent EigenMaps builds of
+/// the same fixed dataset with the same config and seed
+/// (`deterministic_clustering = true`) must return byte-identical λ vectors,
+/// while the global rayon pool is saturated by unrelated work.
+#[test]
+#[serial]
+fn test_eigen_build_lambda_bit_reproducible_under_pool_saturation() {
+    init();
+
+    let rows = make_gaussian_hd(160, 0.5);
+    let build_lambdas = || {
+        let dense = DenseMatrix::from_2d_vec(&rows).unwrap();
+        // Config mirrors the downstream reproduction in #170:
+        // eps=0.5, k=5, topk=3, p=2.0, sigma=None, clustering_seed=3407.
+        ArrowSpaceBuilder::new()
+            .with_lambda_graph(0.5, 5, 3, 2.0, None)
+            .with_synthesis(TauMode::Median)
+            .with_dims_reduction(false, None)
+            .with_inline_sampling(None)
+            .with_seed(3407)
+            .build_for_persistence(dense, PipelineKind::Eigen)
+            .0
+            .lambdas()
+            .to_vec()
+    };
+
+    let _sat = PoolSaturator::start();
+    let reference = build_lambdas();
+    for build_idx in 1..4 {
+        let lambdas = build_lambdas();
+        assert_eq!(reference.len(), lambdas.len());
+        for (i, (&a, &b)) in reference.iter().zip(lambdas.iter()).enumerate() {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "λ[{i}] not byte-identical across builds (build {build_idx}): {a:e} vs {b:e}"
+            );
+        }
+    }
+}

--- a/src/tests/test_smartcore_percolation.rs
+++ b/src/tests/test_smartcore_percolation.rs
@@ -100,7 +100,8 @@ fn cosinepair_knn_finds_both_trio_siblings_exactly() {
             .filter(|(j, _)| *j == sib_a || *j == sib_b)
             .count();
         assert_eq!(
-            found_sibs, 2,
+            found_sibs,
+            2,
             "row {}: exact kNN must contain both siblings {:?}, got {:?}",
             i,
             (sib_a, sib_b),

--- a/src/tests/test_taumode.rs
+++ b/src/tests/test_taumode.rs
@@ -1,4 +1,3 @@
-
 // Exercises the deprecated panicking wrappers on purpose:
 // the backward-compat surface must keep its documented panic behaviour (#153).
 #![allow(deprecated)]


### PR DESCRIPTION
## Summary

Fixes #170. `deterministic_clustering` (set by `ArrowSpaceBuilder::with_seed`) did not make EigenMaps builds bit-reproducible: two independent `build_for_persistence(data, PipelineKind::Eigen)` calls on identical input with identical config could return λ vectors differing by up to ~1 ULP, intermittently, when the global rayon pool was busy.

## Root cause

`TauMode::compute_rayleigh_quotient_from_matrix` reduced the Rayleigh numerator with `outer_iterator().enumerate().par_bridge().map(...).sum()`. `par_bridge` batches its source by dynamic work-stealing, so the f64 addends grouped in a schedule-dependent order — and f64 addition is not associative. Every λ derived from the quotient drifted with it. The denominator (`vector.par_iter().map(|x| x*x).sum()`) was indexed and schedule-independent *within a process*, but its reduce tree still split by pool thread count, so bits could vary across machine configurations.

## Fix

Determinism by construction, no dependence on scheduling at any point:

- per-row partial terms (`x_i · Σ_j M_ij x_j`) computed in parallel — each row's inner sum is a sequential pass over its nonzeros in index order, so its bits are independent of the evaluating thread — and collected into an index-addressed `Vec<f64>`;
- numerator: sequential fixed-order pass over the per-row terms;
- denominator: sequential fixed-order pass over the vector.

Identical inputs now produce bit-identical λ on any machine, any pool size, any load. No summation grouping depends on thread scheduling any more.

## Tests

TDD: regression tests written first and confirmed failing on `d116cb7` (last-bit drift on the first loaded call, 3/3 runs).

New `src/tests/test_lambda_determinism.rs`:
- `test_rayleigh_quotient_bit_reproducible_under_pool_saturation` — 512 evaluations of a fixed (sparse Laplacian, vector) fixture while the global pool is saturated by CPU-bound work; asserts bit-identical results.
- `test_eigen_build_lambda_bit_reproducible_under_pool_saturation` — the acceptance criterion from #170: repeated seeded Eigen builds (`seed=3407`, eps=0.5, k=5, topk=3) of a fixed 160×100 dataset under pool saturation assert byte-identical λ vectors.

## Documentation

- Reproducibility contract stated on `with_seed` and `build_for_persistence`: seeded builds of identical input return byte-identical λ vectors, by construction rather than by tolerance.
- CHANGELOG entry for 0.28.1.

## Verification

- `cargo test --release --lib`: 304 passed, 0 failed (regression tests 5/5 stress runs stable).
- `cargo clippy --all-features -- -Drust-2018-idioms -Dwarnings`: clean.
- `cargo fmt` applied; `cargo test --release --doc`: clean.
- Audit: no other `par_bridge` float-reduction exists in the crate (single occurrence, removed). `compute_item_dispersion` is already sequential.

## Value-level note

λ values change only in the last bits (summation order changed); graph structure, clustering and λ semantics are untouched. Downstream consumers that pin λ by exact equality across builds (e.g. genefold-vd append-vs-rebuild checks) can rely on bit-exactness again.